### PR TITLE
bugfix and QoL change

### DIFF
--- a/DoomRPG/scripts/Outpost.c
+++ b/DoomRPG/scripts/Outpost.c
@@ -1538,7 +1538,9 @@ NamedScript MapSpecial void ShopSpecial()
 NamedScript MapSpecial void MissionBBS()
 {
     int Index;
-    int Difficulty;
+    int Difficulty = (Player.RankLevel - 1) / 2.0;
+    if (Difficulty >= MAX_DIFFICULTIES - 1)
+        Difficulty = MAX_DIFFICULTIES - 1;
 
     // If Marines are hostile, terminate
     if (MarinesHostile) return;

--- a/DoomRPG/scripts/Utils.c
+++ b/DoomRPG/scripts/Utils.c
@@ -2309,6 +2309,7 @@ void RemoveDRLAArmorToken(str ArmorType)
 
 void CheckDRLASetWeapons()
 {
+    bool hasNuclearWeapon = false;
     str const NuclearWeapons[15] =
     {
         // Nuclear Plasma Pistol
@@ -2343,17 +2344,24 @@ void CheckDRLASetWeapons()
         "RLNuclearOnslaught"
     };
 
-    // Weapon portion of Nuclear Set Bonus Checking
-    for (int i = 0; i < 15; i++)
-        if (!CheckInventory(NuclearWeapons[i]))
+    if (CheckInventory("RLNuclearWeaponSetBonusWeapon"))
+    {
+        // Weapon portion of Nuclear Set Bonus Checking
+        for (int i = 0; i < 15; i++)
+            if (CheckInventory(NuclearWeapons[i]))
+            {
+                hasNuclearWeapon = true;
+                break;
+            }
+        if (!hasNuclearWeapon)
         {
             TakeInventory("RLNuclearWeaponSetBonusWeapon", 1);
             TakeInventory("RLNuclearWeaponSetBonusActive", 1);
-            break;
         }
+    }
 
     // Tristar blaster Set Bonus Checking
-    if (!CheckInventory("RLTristarBlaster") || !CheckInventory("RLHighPowerTristarBlaster") || !CheckInventory("RLNanomanufactureAmmoTristarBlaster"))
+    if (!CheckInventory("RLTristarBlaster") && !CheckInventory("RLHighPowerTristarBlaster") && !CheckInventory("RLNanomanufactureAmmoTristarBlaster"))
     {
         TakeInventory("RLCerberusSetBonusTristarBlaster", 1);
         TakeInventory("RLCerberusSetBonusActive", 1);


### PR DESCRIPTION
fix: CheckDRLASetWeapons kept deleting set bonuses that require a weapon
change: mission select screen opens to max difficulty unlocked, because presumably you'll want to start at the most valuable missions instead of the least valuable