### PR TITLE
health/regen fixes

### DIFF
--- a/DoomRPG-RLArsenal-Extended/zscript/DRLAX/familiars/Special.zscript
+++ b/DoomRPG-RLArsenal-Extended/zscript/DRLAX/familiars/Special.zscript
@@ -146,6 +146,9 @@ class DRLAX_DarkMartyFamiliar : DRLAX_FamiliarBase
             
             ThinkerIterator ti = ThinkerIterator.Create("Actor");
             Actor a;
+	    class<actor> BigTree = GetReplacement("BigTree");
+            class<actor> TorchTree = GetReplacement("TorchTree");
+            class<actor> Stalagtite = GetReplacement("Stalagtite");
             while(a = Actor(ti.Next()))
             {
                 if(f.treeCount == 12)
@@ -153,7 +156,7 @@ class DRLAX_DarkMartyFamiliar : DRLAX_FamiliarBase
                     break;
                 }
 
-                if(a is "BigTree" || a is "MetaBigTree" || a is "TorchTree" || a is "MetaTorchTree" || a is "Stalagtite")
+                if(a is BigTree || a is TorchTree || a is Stalagtite)
                 {
                     f.treeCount++;
                 }

--- a/DoomRPG/scripts/Augs.c
+++ b/DoomRPG/scripts/Augs.c
@@ -439,11 +439,11 @@ void CheckAugs()
     {
         if (Player.Augs.CurrentLevel[AUG_REGENERATION] >= 1)
         {
-            Player.HPTime *= 0.75;
+            Player.HPTime /= 1.25;
         }
         if (Player.Augs.CurrentLevel[AUG_REGENERATION] >= 2)
         {
-            Player.EPTime *= 0.75;
+            Player.EPTime /= 1.25;
         }
         if (Player.Augs.CurrentLevel[AUG_REGENERATION] >= 3)
         {

--- a/DoomRPG/scripts/RPG.c
+++ b/DoomRPG/scripts/RPG.c
@@ -659,64 +659,71 @@ NamedScript DECORATE int AddHealth(int HealthPercent, int MaxPercent)
     int RealMax = Player.HealthMax * MaxPercent / 100;
     int HealthAmount = Player.HealthMax * HealthPercent / 100;
 
-    if (Player.OverHeal)
-        if (MaxPercent >= 200 && Player.ActualHealth + HealthAmount >= RealMax)
-            Player.OverHeal = false;
-
-    if (HealthAmount > 0 && Player.ActualHealth >= RealMax)
-        return 0;
-
-    if (Player.ActualHealth + HealthAmount > RealMax)
-        HealthAmount = RealMax - Player.ActualHealth;
-
-    // Add Vitality XP for using healing items
-    if (GetCVar("drpg_levelup_natural"))
+    if (HealthPercent > 0) //to make this consistent with how AddHealthDirect handles non-positive values
     {
-        fixed Scale = GetCVarFixed("drpg_vitality_scalexp");
-        if (GetCVar("drpg_allow_spec"))
-        {
-            if (GetActivatorCVar("drpg_character_spec") == 3)
-                Scale *= 2;
-        }
+        if (Player.OverHeal)
+            if (MaxPercent >= 200 && Player.ActualHealth + HealthAmount >= RealMax)
+                Player.OverHeal = false;
 
-        int Factor = CalcPercent(HealthAmount, Player.HealthMax);
-        Player.VitalityXP += (int)(Factor * Scale * 10);
+        if (HealthAmount > 0 && Player.ActualHealth >= RealMax)
+            return 0;
+
+        if (Player.ActualHealth + HealthAmount > RealMax)
+            HealthAmount = RealMax - Player.ActualHealth;
+
+        // Add Vitality XP for using healing items
+        if (GetCVar("drpg_levelup_natural"))
+        {
+            fixed Scale = GetCVarFixed("drpg_vitality_scalexp");
+            if (GetCVar("drpg_allow_spec"))
+            {
+                if (GetActivatorCVar("drpg_character_spec") == 3)
+                    Scale *= 2;
+            }
+
+            int Factor = CalcPercent(HealthAmount, Player.HealthMax);
+            Player.VitalityXP += (int)(Factor * Scale * 10);
+        }
     }
 
     Player.ActualHealth += HealthAmount;
-    return 1;
+    HealthPercent = HealthAmount * 100 / Player.HealthMax;
+    return HealthPercent;
 }
 
 NamedScript DECORATE int AddHealthDirect(int HealthAmount, int MaxPercent)
 {
     int RealMax = Player.HealthMax * MaxPercent / 100;
 
-    if (Player.OverHeal)
-        if (MaxPercent >= 200 && Player.ActualHealth + HealthAmount >= RealMax)
-            Player.OverHeal = false;
-
-    if (HealthAmount > 0 && Player.ActualHealth >= RealMax)
-        return 0;
-
-    if (Player.ActualHealth + HealthAmount > RealMax)
-        HealthAmount = RealMax - Player.ActualHealth;
-
-    // Add Vitality XP for using healing items
-    if (GetCVar("drpg_levelup_natural"))
+    if (HealthAmount > 0) //basically none of this applies if you're being directly hurt, or if HealthAmount is zero somehow
     {
-        fixed Scale = GetCVarFixed("drpg_vitality_scalexp");
-        if (GetCVar("drpg_allow_spec"))
-        {
-            if (GetActivatorCVar("drpg_character_spec") == 3)
-                Scale *= 2;
-        }
+        if (Player.OverHeal)
+            if (MaxPercent >= 200 && Player.ActualHealth + HealthAmount >= RealMax)
+                Player.OverHeal = false;
 
-        int Factor = CalcPercent(HealthAmount, Player.HealthMax);
-        Player.VitalityXP += (int)(Factor * Scale * 10);
+        if (Player.ActualHealth >= RealMax)
+            return 0;
+
+        if (Player.ActualHealth + HealthAmount > RealMax)
+            HealthAmount = RealMax - Player.ActualHealth;
+
+        // Add Vitality XP for using healing items
+        if (GetCVar("drpg_levelup_natural"))
+        {
+            fixed Scale = GetCVarFixed("drpg_vitality_scalexp");
+            if (GetCVar("drpg_allow_spec"))
+            {
+                if (GetActivatorCVar("drpg_character_spec") == 3)
+                    Scale *= 2;
+            }
+
+            int Factor = CalcPercent(HealthAmount, Player.HealthMax);
+            Player.VitalityXP += (int)(Factor * Scale * 10);
+        }
     }
 
     Player.ActualHealth += HealthAmount;
-    return 1;
+    return HealthAmount;
 }
 
 typedef struct

--- a/DoomRPG/scripts/Stats.c
+++ b/DoomRPG/scripts/Stats.c
@@ -788,7 +788,7 @@ void DoRegen()
         HealThing(Player.HPAmount);
 
     // EP Regen
-    if (Player.EPRate >= Player.EPTime && Player.EP < Player.EPMax)
+    if (Player.EPRate >= Player.EPTime)
     {
         Player.EP += Player.EPAmount;
         Overflow = 0;
@@ -842,7 +842,7 @@ void DoRegen()
         HPAmount += Multiplier * Multiplier;
 
         // EP
-        fixed EP = Abs(Player.EP);
+        fixed EP = Max(Player.EP, 0);
         fixed MaxEP = Player.EPMax;
 
         Multiplier = (1.0 - ((fixed)EP / (fixed)MaxEP)) * 1.77;


### PR DESCRIPTION
AddHealth and AddHealthDirect would give negative vitality XP if the health bonus was negative. they'd also delete any HP over MaxPercent, which may have been intentional, but the only use case is the Unmaker altfire health drain and I don't think it's supposed to function that way for more than one reason. as such I've removed this health capping behavior.

changed return value from 1 to the amount healed, so the caller can know how much of the heal was applied, rather than if it was successful or not.