### PR TITLE
Develop

### DIFF
--- a/DoomRPG-Compendium/CCARDS.txt
+++ b/DoomRPG-Compendium/CCARDS.txt
@@ -1,0 +1,1 @@
+excludemap HUBMAP

--- a/DoomRPG-CorruptionCards/CCARDS.txt
+++ b/DoomRPG-CorruptionCards/CCARDS.txt
@@ -1,1 +1,3 @@
 excludemap OUTPOST
+excludemap HUBMAP
+excludemap VR

--- a/DoomRPG-CorruptionCards/CCARDS.txt
+++ b/DoomRPG-CorruptionCards/CCARDS.txt
@@ -1,3 +1,1 @@
 excludemap OUTPOST
-excludemap HUBMAP
-excludemap VR

--- a/DoomRPG-Lexicon/CCARDS.txt
+++ b/DoomRPG-Lexicon/CCARDS.txt
@@ -1,0 +1,1 @@
+excludemap VR

--- a/DoomRPG/GAMEINFO.txt
+++ b/DoomRPG/GAMEINFO.txt
@@ -1,3 +1,3 @@
-startuptitle = "Doom RPG SE Rebalance (2022-08-19)"
+startuptitle = "Doom RPG SE Rebalance (2022-08-20)"
 startupcolors = "0092FF", "000000"
 startuptype = "Hexen"

--- a/DoomRPG/GAMEINFO.txt
+++ b/DoomRPG/GAMEINFO.txt
@@ -1,3 +1,3 @@
-startuptitle = "Doom RPG SE Rebalance (2022-08-20)"
+startuptitle = "Doom RPG SE Rebalance (2022-08-21)"
 startupcolors = "0092FF", "000000"
 startuptype = "Hexen"

--- a/DoomRPG/scripts/Map.c
+++ b/DoomRPG/scripts/Map.c
@@ -3751,7 +3751,7 @@ NamedScript void InitMapPacks()
         "WOS01",
         "ZTH01",
         "ZOF01",
-        "HUBMAP",    // Compemdium
+        "HUBMAP",    // Compendium
         "MM101",
         "MM201",
         "REQ01",

--- a/DoomRPG/scripts/Outpost.c
+++ b/DoomRPG/scripts/Outpost.c
@@ -86,11 +86,14 @@ NamedScript MapSpecial void EnterOutpost()
 
         // Make the Marines fight enemies in title map only if Toaster Mod is off
         if (!GetCVar("drpg_toaster"))
+        {
             PissOffMarines(false);
 
+            if (CompatMonMode == COMPAT_DRLA)
+                AmbientSound("nightmarecyberdemon/sight", 127);
+        }
+
         ActivatorSound("misc/skillchange", 127);
-        if (CompatMonMode == COMPAT_DRLA)
-            AmbientSound("nightmarecyberdemon/sight", 127);
 
         while (InTitle)
         {
@@ -423,7 +426,7 @@ NamedScript MapSpecial void LevelTransport()
         "Whispers Of Satan",
         "Zone 300",
         "Zones Of Fear",
-        "Compemdium's Hub",    // Compemdium
+        "Compendium's Hub",    // Compendium
         "Memento Mori",
         "Memento Mori II",
         "Requiem",


### PR DESCRIPTION
@quippo0
- AddHealth and AddHealthDirect would give negative vitality XP if the health bonus was negative. they'd also delete any HP over MaxPercent, which may have been intentional, but the only use case is the Unmaker altfire health drain and I don't think it's supposed to function that way for more than one reason. as such I've removed this health capping behavior.
- changed return value from 1 to the amount healed, so the caller can know how much of the heal was applied, rather than if it was successful or not.