### PR TITLE
Develop

### DIFF
--- a/DoomRPG-CorruptionCards/MENUDEF.txt
+++ b/DoomRPG-CorruptionCards/MENUDEF.txt
@@ -12,5 +12,5 @@ OptionMenu "Corruption Cards Options"
     Option "Generate new cards on the second visit to the map", "ccards_allowreturnmaps", "OnOff"
     StaticText ""
     StaticText "Note: turn off is recommended for Hardcore mode"
-    StaticText "(or a similar mode with permanent cards at each level)"
+    StaticText "(or a similar mode with permanent cards at each map)"
 }

--- a/DoomRPG/GAMEINFO.txt
+++ b/DoomRPG/GAMEINFO.txt
@@ -1,3 +1,3 @@
-startuptitle = "Doom RPG SE Rebalance (2022-08-21)"
+startuptitle = "Doom RPG SE Rebalance (2022-08-22)"
 startupcolors = "0092FF", "000000"
 startuptype = "Hexen"

--- a/DoomRPG/scripts/Outpost.c
+++ b/DoomRPG/scripts/Outpost.c
@@ -4863,10 +4863,12 @@ NamedScript MapSpecial void DemonAssemblingSanctuary()
                     TakeInventory(ItemData[7][CurrentTypeDetails2].Actor, CurrentAmountDetails2);
                     TakeInventory(ItemData[7][CurrentTypeDetails3].Actor, CurrentAmountDetails3);
                     TakeInventory(ItemData[8][CurrentTypeDetails4].Actor, CurrentAmountDetails4);
-                    for(int i = 0; i < CurrentAmountDetails4; i++)
-                        RemoveDRLAItem(8, CurrentTypeDetails4);
                     TakeInventory(ItemData[4][CurrentTypeDetails5].Actor, CurrentAmountDetails5);
                     TakeInventory(ItemData[6][CurrentTypeDetails6].Actor, CurrentAmountDetails6);
+
+                    // Take Demon Artifacts Limit tokens from DoomRL Arsenal
+                    for(int i = 0; i < CurrentAmountDetails4; i++)
+                        RemoveDRLAItem(8, CurrentTypeDetails4);
 
                     // The effect of sleep immersion
                     FadeRange(0, 0, 0, 0.5, 0, 0, 0, 1.0, 1.0);


### PR DESCRIPTION
@quippo0:
Minigame update:
- added minor variance to initial spin speed, so you can't just hit the item you're aiming for 100% of the time;
- made luck stat influence speed variance, reaching minimum variance at 100 luck;
- tied ticking sound to when the wheel actually ticks over different items, so the sound slows down as the wheel slows down;
- made the wheel settle onto the item before it spits out the item.