### PR TITLE
regen rate fixes

### DIFF
--- a/DoomRPG/scripts/Menu.c
+++ b/DoomRPG/scripts/Menu.c
@@ -681,9 +681,9 @@ void DrawStatsMenu()
         EndHudMessage(HUDMSG_PLAIN, 0, "LightBlue",          230.1,  102.0,  0.05);
         HudMessage("%d Aura Range", (int)Player.Aura.Range);
         EndHudMessage(HUDMSG_PLAIN, 0, "LightBlue",          230.1,  110.0,  0.05);
-        HudMessage("HP Timer: %.2k Sec", (fixed)(Player.HPTime / (35.0K * 2.0K)));
+        HudMessage("HP Timer: %.2k Sec", (fixed)(Player.HPTime / 35.0K));
         EndHudMessage(HUDMSG_PLAIN, 0, "Brick",              30.1,   136.0,  0.05);
-        HudMessage("EP Timer: %.2k Sec", (fixed)(Player.EPTime / (35.0K * 2.0K)));
+        HudMessage("EP Timer: %.2k Sec", (fixed)(Player.EPTime / 35.0K));
         EndHudMessage(HUDMSG_PLAIN, 0, "LightBlue",          30.1,   144.0,  0.05);
         HudMessage("Regen Sphere: %d Sec", (int)(15 + (Player.RegenerationTotal / 2)));
         EndHudMessage(HUDMSG_PLAIN, 0, "Purple",             30.1,   152.0,  0.05);

--- a/DoomRPG/scripts/Menu.c
+++ b/DoomRPG/scripts/Menu.c
@@ -908,23 +908,28 @@ void DrawStatsMenu()
     // Perks Page
     case STATPAGE_PERKS:
     {
+        bool naturalStats = GetCVar("drpg_levelup_natural");
+
         // Holds the perk information
-        str const PerkInfo[STAT_MAX][3] =
+        str const PerkInfo[STAT_MAX][4] =
         {
             // Strength
             {
+                StrParam("Level %d:", (naturalStats ? 150 : 75)),
                 "Damage exponentially increases as health lowers",
                 NULL
             },
 
             // Defense
             {
+                StrParam("Level %d:", (naturalStats ? 150 : 75)),
                 "Damage taken exponentially decreases as health lowers",
                 NULL
             },
 
             // Vitality
             {
+                StrParam("Level %d:", (naturalStats ? 150 : 75)),
                 "No movement penalties at low health",
                 "2x HP regeneration rate below 20% health",
                 NULL
@@ -932,6 +937,7 @@ void DrawStatsMenu()
 
             // Energy
             {
+                StrParam("Level %d:", (naturalStats ? 100 : 50)),
                 "2x EP regeneration rate when burned out",
                 "Can stack an extra Aura every 25 Energy invested",
                 NULL
@@ -939,12 +945,14 @@ void DrawStatsMenu()
 
             // Regeneration
             {
+                StrParam("Level %d:", (naturalStats ? 150 : 75)),
                 "Regeneration speeds increase as your HP/EP gets lower",
                 NULL
             },
 
             // Agility
             {
+                StrParam("Level %d:", (naturalStats ? 150 : 75)),
                 "+15% Survival Bonus",
                 "Movement increases Regeneration speed",
                 NULL
@@ -952,12 +960,14 @@ void DrawStatsMenu()
 
             // Capacity
             {
+                StrParam("Level %d:", (naturalStats ? 200 : 100)),
                 "Ammo regeneration",
                 NULL
             },
 
             // Luck
             {
+                StrParam("Level %d:", (naturalStats ? 200 : 100)),
                 "Always have full automap",
                 NULL
             }
@@ -975,7 +985,7 @@ void DrawStatsMenu()
                 PrintSpriteAlpha(StrParam("STAT%d", i + 1), 0, 16.1, 56.1 + (i * 44.0), 0.05, 0.5);
 
             // Build description string
-            for (int j = 0; PerkInfo[i][j] != NULL; j++)
+            for (int j = (Player.Perks[i] ? 1 : 0); PerkInfo[i][j] != NULL; j++)
                 Description = StrParam("%S%S\n", Description, PerkInfo[i][j]);
 
             // Determine Color

--- a/DoomRPG/scripts/Stats.c
+++ b/DoomRPG/scripts/Stats.c
@@ -528,12 +528,12 @@ void CheckStats()
     Player.EPMax = 50 + ((Player.Level + 1) / 2) * 5 + Player.EnergyTotal * 5;
     Player.Aura.Range = Player.EnergyTotal * 16;
     Player.ToxicityRegenBonus = Player.RegenerationTotal / 10;
-    Player.JumpHeight = 8.0 + (2.0 * ((fixed)Player.Agility / 100));
+    Player.JumpHeight = 8.0;
     Player.WeaponSpeed = Player.AgilityTotal / 2;
     SetAmmoCapacity("Clip", (int)(115 + Player.CapacityTotal * 7.5) / 10 * 10);
     SetAmmoCapacity("Shell", 20 + Player.CapacityTotal * 2);
-    SetAmmoCapacity("RocketAmmo", 20 + Player.CapacityTotal * 2);
-    SetAmmoCapacity("Cell", (int)(115 + Player.CapacityTotal * 7.5) / 10 * 10);
+    SetAmmoCapacity("RocketAmmo", 2 + Player.CapacityTotal * 0.6);
+    SetAmmoCapacity("Cell", (75 + Player.CapacityTotal * 5) / 10 * 10);
     Player.Stim.VialMax = Player.CapacityTotal * 2.5;
     Player.SurvivalBonus = Player.AgilityTotal / 5;
     if (CompatMode == COMPAT_DRLA) // DRLA - Total Armors/Boots, Skulls

--- a/DoomRPG/scripts/Stats.c
+++ b/DoomRPG/scripts/Stats.c
@@ -1080,22 +1080,23 @@ void CheckPerks()
 {
     // If you're dead, return
     if (GetActorProperty(Player.TID, APROP_Health) <= 0) return;
+    bool naturalStats = GetCVar("drpg_levelup_natural");
 
-    if (Player.StrengthTotal >= (GetCVar("drpg_levelup_natural") ? 150 : 75))     Player.Perks[STAT_STRENGTH] = true;
+    if (Player.StrengthTotal >= (naturalStats ? 150 : 75))     Player.Perks[STAT_STRENGTH] = true;
     else Player.Perks[STAT_STRENGTH] = false;
-    if (Player.DefenseTotal >= (GetCVar("drpg_levelup_natural") ? 150 : 75))      Player.Perks[STAT_DEFENSE] = true;
+    if (Player.DefenseTotal >= (naturalStats ? 150 : 75))      Player.Perks[STAT_DEFENSE] = true;
     else Player.Perks[STAT_DEFENSE] = false;
-    if (Player.VitalityTotal >= (GetCVar("drpg_levelup_natural") ? 150 : 75))     Player.Perks[STAT_VITALITY] = true;
+    if (Player.VitalityTotal >= (naturalStats ? 150 : 75))     Player.Perks[STAT_VITALITY] = true;
     else Player.Perks[STAT_VITALITY] = false;
-    if (Player.EnergyTotal >= (GetCVar("drpg_levelup_natural") ? 100 : 50))       Player.Perks[STAT_ENERGY] = true;
+    if (Player.EnergyTotal >= (naturalStats ? 100 : 50))       Player.Perks[STAT_ENERGY] = true;
     else Player.Perks[STAT_ENERGY] = false;
-    if (Player.RegenerationTotal >= (GetCVar("drpg_levelup_natural") ? 150 : 75)) Player.Perks[STAT_REGENERATION] = true;
+    if (Player.RegenerationTotal >= (naturalStats ? 150 : 75)) Player.Perks[STAT_REGENERATION] = true;
     else Player.Perks[STAT_REGENERATION] = false;
-    if (Player.AgilityTotal >= (GetCVar("drpg_levelup_natural") ? 150 : 75))      Player.Perks[STAT_AGILITY] = true;
+    if (Player.AgilityTotal >= (naturalStats ? 150 : 75))      Player.Perks[STAT_AGILITY] = true;
     else Player.Perks[STAT_AGILITY] = false;
-    if (Player.CapacityTotal >= (GetCVar("drpg_levelup_natural") ? 200 : 100))    Player.Perks[STAT_CAPACITY] = true;
+    if (Player.CapacityTotal >= (naturalStats ? 200 : 100))    Player.Perks[STAT_CAPACITY] = true;
     else Player.Perks[STAT_CAPACITY] = false;
-    if (Player.LuckTotal >= (GetCVar("drpg_levelup_natural") ? 200 : 100))        Player.Perks[STAT_LUCK] = true;
+    if (Player.LuckTotal >= (naturalStats ? 200 : 100))        Player.Perks[STAT_LUCK] = true;
     else Player.Perks[STAT_LUCK] = false;
 
     fixed StrengthPercent = ((fixed)Player.ActualHealth / (fixed)Player.HealthMax * 100);

--- a/DoomRPG/scripts/inc/Structs.h
+++ b/DoomRPG/scripts/inc/Structs.h
@@ -667,6 +667,7 @@ struct PlayerData_S
     int EPTime;
     int EPAmount;
     int RegenBoostTimer;
+    bool MovementRegenDelay;
 
     // Can Drop / Drop Chance Percentages
     bool HealthDrop;


### PR DESCRIPTION
fixed regen timers in stats menu displaying twice the actual time
made movement-based regen rates match what the comments said they should be

added perk level requirements display in stat menu perk page, because I forgot this was already open