### PR TITLE
Develop

### DIFF
--- a/DoomRPG-CorruptionCards/MENUDEF.txt
+++ b/DoomRPG-CorruptionCards/MENUDEF.txt
@@ -12,5 +12,5 @@ OptionMenu "Corruption Cards Options"
     Option "Generate new cards on the second visit to the map", "ccards_allowreturnmaps", "OnOff"
     StaticText ""
     StaticText "Note: turn off is recommended for Hardcore mode"
-    StaticText "(or a similar mode with permanent cards at each level)"
+    StaticText "(or a similar mode with permanent cards at each map)"
 }

--- a/DoomRPG-RLArsenal-Extended/zscript/DRLAX/Gizmos.zscript
+++ b/DoomRPG-RLArsenal-Extended/zscript/DRLAX/Gizmos.zscript
@@ -240,8 +240,9 @@ Class DRLAX_GizmoHandler : Thinker
         }
 
 		ss.speed = 3;
+
+		return true;
 	}
-	return true;
 }
 
 Class DRLAX_GizmoObject : Actor

--- a/DoomRPG/GAMEINFO.txt
+++ b/DoomRPG/GAMEINFO.txt
@@ -1,3 +1,3 @@
-startuptitle = "Doom RPG SE Rebalance (2022-08-22)"
+startuptitle = "Doom RPG SE Rebalance (2022-08-23)"
 startupcolors = "0092FF", "000000"
 startuptype = "Hexen"

--- a/DoomRPG/GAMEINFO.txt
+++ b/DoomRPG/GAMEINFO.txt
@@ -1,3 +1,3 @@
-startuptitle = "Doom RPG SE Rebalance (2022-08-21)"
+startuptitle = "Doom RPG SE Rebalance (2022-08-22)"
 startupcolors = "0092FF", "000000"
 startuptype = "Hexen"

--- a/DoomRPG/scripts/Augs.c
+++ b/DoomRPG/scripts/Augs.c
@@ -63,7 +63,7 @@ AugInfo RPGMap AugData[AUG_MAX] =
             "+50% EP Regen Amounts",
             "+25% Max EP Amounts",
             "+50% Max EP Amounts",
-            "+50% Aura Timer",
+            "+50% Aura Timer and +1 Aura Max Stack",
             "+10% Skill Cost Refund",
             "+15% Skill Cost Refund",
             "+20% Skill Cost Refund",

--- a/DoomRPG/scripts/Menu.c
+++ b/DoomRPG/scripts/Menu.c
@@ -915,21 +915,21 @@ void DrawStatsMenu()
         {
             // Strength
             {
-                StrParam("Level %d:", (naturalStats ? 150 : 75)),
+                StrParam("Strength level - %d:", (naturalStats ? 150 : 75)),
                 "Damage exponentially increases as health lowers",
                 NULL
             },
 
             // Defense
             {
-                StrParam("Level %d:", (naturalStats ? 150 : 75)),
+                StrParam("Defense level - %d:", (naturalStats ? 150 : 75)),
                 "Damage taken exponentially decreases as health lowers",
                 NULL
             },
 
             // Vitality
             {
-                StrParam("Level %d:", (naturalStats ? 150 : 75)),
+                StrParam("Vitality level - %d:", (naturalStats ? 150 : 75)),
                 "No movement penalties at low health",
                 "2x HP regeneration rate below 20% health",
                 NULL
@@ -937,22 +937,22 @@ void DrawStatsMenu()
 
             // Energy
             {
-                StrParam("Level %d:", (naturalStats ? 100 : 50)),
+                StrParam("Energy level - %d:", (naturalStats ? 100 : 50)),
                 "2x EP regeneration rate when burned out",
-                "Can stack an extra Aura every 25 Energy invested",
+                (naturalStats ? "Can stack an extra Aura every 50 Energy invested" : "Can stack an extra Aura every 25 Energy invested"),
                 NULL
             },
 
             // Regeneration
             {
-                StrParam("Level %d:", (naturalStats ? 150 : 75)),
+                StrParam("Regen level - %d:", (naturalStats ? 150 : 75)),
                 "Regeneration speeds increase as your HP/EP gets lower",
                 NULL
             },
 
             // Agility
             {
-                StrParam("Level %d:", (naturalStats ? 150 : 75)),
+                StrParam("Agility level - %d:", (naturalStats ? 150 : 75)),
                 "+15% Survival Bonus",
                 "Movement increases Regeneration speed",
                 NULL
@@ -960,14 +960,14 @@ void DrawStatsMenu()
 
             // Capacity
             {
-                StrParam("Level %d:", (naturalStats ? 200 : 100)),
+                StrParam("Capacity level - %d:", (naturalStats ? 200 : 100)),
                 "Ammo regeneration",
                 NULL
             },
 
             // Luck
             {
-                StrParam("Level %d:", (naturalStats ? 200 : 100)),
+                StrParam("Luck level - %d:", (naturalStats ? 200 : 100)),
                 "Always have full automap",
                 NULL
             }

--- a/DoomRPG/scripts/Outpost.c
+++ b/DoomRPG/scripts/Outpost.c
@@ -4863,10 +4863,12 @@ NamedScript MapSpecial void DemonAssemblingSanctuary()
                     TakeInventory(ItemData[7][CurrentTypeDetails2].Actor, CurrentAmountDetails2);
                     TakeInventory(ItemData[7][CurrentTypeDetails3].Actor, CurrentAmountDetails3);
                     TakeInventory(ItemData[8][CurrentTypeDetails4].Actor, CurrentAmountDetails4);
-                    for(int i = 0; i < CurrentAmountDetails4; i++)
-                        RemoveDRLAItem(8, CurrentTypeDetails4);
                     TakeInventory(ItemData[4][CurrentTypeDetails5].Actor, CurrentAmountDetails5);
                     TakeInventory(ItemData[6][CurrentTypeDetails6].Actor, CurrentAmountDetails6);
+
+                    // Take Demon Artifacts Limit tokens from DoomRL Arsenal
+                    for(int i = 0; i < CurrentAmountDetails4; i++)
+                        RemoveDRLAItem(8, CurrentTypeDetails4);
 
                     // The effect of sleep immersion
                     FadeRange(0, 0, 0, 0.5, 0, 0, 0, 1.0, 1.0);

--- a/DoomRPG/scripts/inc/Defs.h
+++ b/DoomRPG/scripts/inc/Defs.h
@@ -753,7 +753,7 @@ typedef enum
 #define LUCK_SHIELDINC          0.0005
 #define LUCK_AUGINC             0.00025
 
-#define AURA_CALCTIME           (((35 * 30) + (35 * Player.EnergyTotal) + (35 * Player.Level * 2)) * (1 + Player.AuraBonus * 0.5))
+#define AURA_CALCTIME           (((GetCVar("drpg_levelup_natural")) ? ((35 * 100) + (35 * Player.EnergyTotal * 2)) : ((35 * 80) + (35 * Player.EnergyTotal * 4))) * (1.0 + Player.AuraBonus * 0.5))
 #define DRLA_WEAPON_MAX         6
 #define DRLA_ARMOR_MAX          2 + ((GetCVar("drpg_levelup_natural")) ? (Player.CapacityTotal / 50) : (Player.CapacityTotal / 25))
 #define DRLA_SKULL_MAX          DRLA_ARMOR_MAX


### PR DESCRIPTION
@quippo0:
- fixed regen timers in stats menu displaying twice the actual time;
- made movement-based regen rates match what the comments said they should be;
- added perk level requirements display in stat menu perk page, because I forgot this was already open;
- fixed excess DRLAX items disappearing.

@WNC12k:
- added "+1 Aura Max Stack" for 4 level Psi Projector AUG;
- change formula for calculating aura time;
- now max aura time is 20 min;
- now, if the natural leveling up is enabled, the energy perk looks like "Can stack an extra aura for every 50 energy invested". Instead of 25 previously.