### PR TITLE
Auras balance changes

### DIFF
--- a/DoomRPG/scripts/Skills.c
+++ b/DoomRPG/scripts/Skills.c
@@ -3026,7 +3026,7 @@ NamedScript void TransportInFX(int tid)
     SetActorPropertyFixed(0, APROP_Alpha, 1.0);
 }
 
-NamedScript DECORATE void RemoveAura()
+NamedScript DECORATE void RemoveAura(bool SaveSkillCostMult)
 {
     Player.Aura.Time = 0;
     Player.Aura.Team = false;
@@ -3036,6 +3036,9 @@ NamedScript DECORATE void RemoveAura()
         Player.Aura.Type[i].Active = false;
         Player.Aura.Type[i].Level = 0;
     }
+
+    if (!SaveSkillCostMult)
+        Player.SkillCostMult = 0;
 }
 
 NamedScript DECORATE void ClearStatusEffects()

--- a/DoomRPG/scripts/Stats.c
+++ b/DoomRPG/scripts/Stats.c
@@ -1279,7 +1279,7 @@ void CheckStatusEffects()
     }
 
     if (Player.StatusType[SE_SILENCE]) // Silence
-        RemoveAura();
+        RemoveAura(true);
 
     if (Player.StatusType[SE_CURSE]) // Curse
         Player.DamageFactor = Player.DamageFactor * (1.0 * (Player.StatusIntensity[SE_CURSE] + 1));

--- a/DoomRPG/scripts/inc/Skills.h
+++ b/DoomRPG/scripts/inc/Skills.h
@@ -56,7 +56,7 @@ NamedScript Console bool Transport(SkillLevelInfo *, void *);
 // --------------------------------------------------
 // Utility Scripts
 
-NamedScript DECORATE void RemoveAura();
+NamedScript DECORATE OptionalArgs(1) void RemoveAura(bool);
 NamedScript DECORATE void ClearStatusEffects();
 NamedScript void TransportOutFX(int);
 NamedScript void TransportInFX(int);


### PR DESCRIPTION
- Increased Skill Cost is not saved when moving to another map if option "Keep Auras between levels" is turned off.