### PR TITLE
LegenDoom-aware spawning and drops

### DIFF
--- a/DoomRPG/scripts/Monsters.c
+++ b/DoomRPG/scripts/Monsters.c
@@ -3002,6 +3002,12 @@ NamedScript void MonsterDeath()
 
         Delay(1);
 
+        // LegenDoom monster drops
+        if (CheckInventory("LDLegendaryMonsterToken") && GetCVar("LD_droptype") == 1)
+        {
+            DropMonsterItem(Killer, 0, "DRPGLuckDropper", 256);
+        }
+
         // Boss Drops
         if (Stats->Flags & MF_BOSS)
         {

--- a/DoomRPG/scripts/RPG.c
+++ b/DoomRPG/scripts/RPG.c
@@ -579,15 +579,6 @@ NamedScript DECORATE int PlayerDamage(int Inflictor, int DamageTaken)
 
             return 0;
         }
-
-        // Save ammo for revives
-        if (GetCVar("drpg_multi_revives"))
-        {
-            Player.Ammo.Bullets = CheckInventory("Clip");
-            Player.Ammo.Shells = CheckInventory("Shell");
-            Player.Ammo.Rockets = CheckInventory("RocketAmmo");
-            Player.Ammo.Cells = CheckInventory("Cell");
-        }
     }
 
     SetActorProperty(0, APROP_Health, Player.ActualHealth);
@@ -1707,16 +1698,12 @@ NamedScript Type_RESPAWN void Respawn()
         Delay(4);
     AssignTIDs();
 
-    // Heal to max health if revives are disabled or revive at the body's location and give ammo back
+    // Heal to max health if revives are disabled or revive at the body's location
     if (Player.ReviverTID > 0 && Player.BodyTID > 0)
     {
         SetActorFlag(Player.BodyTID, "INVISIBLE", true);
         SetActorPosition(Player.TID, GetActorX(Player.BodyTID), GetActorY(Player.BodyTID), GetActorZ(Player.BodyTID), false);
         SetActorAngle(Player.TID, GetActorAngle(Player.BodyTID));
-        SetInventory("Clip", Player.Ammo.Bullets);
-        SetInventory("Shell", Player.Ammo.Shells);
-        SetInventory("RocketAmmo", Player.Ammo.Rockets);
-        SetInventory("Cell", Player.Ammo.Cells);
         Thing_Remove(Player.BodyTID);
     }
     else

--- a/DoomRPG/scripts/RPG.c
+++ b/DoomRPG/scripts/RPG.c
@@ -1479,6 +1479,38 @@ NamedScript OptionalArgs(1) void DynamicLootGenerator(str Actor, int MaxItems)
                         SpawnMonster = Actor;
                     if (!Visible && Spawn(SpawnMonster, X, Y, Z, TID, A))
                         Items++;
+
+                    // LegenDoom(Lite) roll
+                    if (CheckClass("LDLegendaryMonsterPickupEasy"))
+                    {
+                        switch (GameSkill())
+                        {
+                        case 0:
+                            GiveActorInventory(TID, "LDLegendaryMonsterPickupEasy", 1);
+                            break;
+                        case 1:
+                            GiveActorInventory(TID, "LDLegendaryMonsterPickupNormal", 1);
+                            break;
+                        case 2:
+                            GiveActorInventory(TID, "LDLegendaryMonsterPickupHard", 1);
+                            break;
+                        case 3:
+                            GiveActorInventory(TID, "LDLegendaryMonsterPickupUV", 1);
+                            break;
+                        case 4:
+                            GiveActorInventory(TID, "LDLegendaryMonsterPickupNightmare", 1);
+                            break;
+                        case 5:
+                            GiveActorInventory(TID, "LDLegendaryMonsterPickupNightmare", 1);
+                            break;
+                        case 6:
+                            GiveActorInventory(TID, "LDLegendaryMonsterPickupNightmare", 1);
+                            break;
+                        case 7:
+                            GiveActorInventory(TID, "LDLegendaryMonsterPickupNightmare", 1);
+                            break;
+                        }
+                    }
                 }
                 else if (Spawn(Actor, X, Y, Z, TID, A))
                     Items++;

--- a/DoomRPG/scripts/inc/Structs.h
+++ b/DoomRPG/scripts/inc/Structs.h
@@ -537,13 +537,6 @@ struct PlayerData_S
 
     // Revive stuff
     int BodyTID;
-    struct
-    {
-        int Bullets;
-        int Shells;
-        int Rockets;
-        int Cells;
-    } Ammo;
     int ReviveKeyTimer;
     int ReviverTID;
 

--- a/DoomRPG/scripts/inc/Structs.h
+++ b/DoomRPG/scripts/inc/Structs.h
@@ -534,7 +534,18 @@ struct PlayerData_S
 {
     int TID;
     int PlayerView;
+
+    // Revive stuff
     int BodyTID;
+    struct
+    {
+        int Bullets;
+        int Shells;
+        int Rockets;
+        int Cells;
+    } Ammo;
+    int ReviveKeyTimer;
+    int ReviverTID;
 
     // Flags
     bool FirstRun;
@@ -739,8 +750,6 @@ struct PlayerData_S
     int StatusTimer[SE_MAX];
     int StatusTimerMax[SE_MAX];
     int Toxicity;
-    int ReviveKeyTimer;
-    int Reviver;
 
     // Locker
     bool LockerMode;

--- a/DoomRPG/zscript/DRPGZHandler.zs
+++ b/DoomRPG/zscript/DRPGZHandler.zs
@@ -147,9 +147,9 @@ class DRPGZEHandler : EventHandler
 
     override void WorldThingDied(WorldEvent e)
     {
-        if (e.Thing) 
+        if (e.Thing && !e.Thing.Player) 
         {
-            if(!e.Thing.bIsMonster && !e.Thing.Player) 
+            if(!e.Thing.bIsMonster) 
             {
                 // Kinsie Metaprops - Tech
                 static const string PropTech[] =


### PR DESCRIPTION
When LegenDoom(Lite) is activated:
1) Additional spawned monsters will roll legendary status
2) Legendary monsters will have better loot drops