### PR TITLE
Arena fix

### DIFF
--- a/DoomRPG/scripts/Arena.c
+++ b/DoomRPG/scripts/Arena.c
@@ -541,7 +541,7 @@ void ArenaCheckMod()
 
 void ArenaSpawnMobs()
 {
-    int MonsterDiffLimit = 2 + ArenaWave;
+    int MonsterDiffLimit = 2 + ArenaWave * ((CompatMonMode == COMPAT_DRLA || CompatMonMode == COMPAT_PANDEMONIA) ? 3 : 1);
     int Spawned;
     int SpawnChanceModifier;
     bool Boss = false;


### PR DESCRIPTION
- now when using DoomRLA Monsters and Pandemonia Monsters, the types of monsters in the arena change more intensively (as they should).