### PR TITLE
Update 1.31a

### DIFF
--- a/DoomRPG/GAMEINFO.txt
+++ b/DoomRPG/GAMEINFO.txt
@@ -1,3 +1,3 @@
-startuptitle = "Doom RPG SE Rebalance (2022-12-20)"
+startuptitle = "Doom RPG SE Rebalance (2023-01-17)"
 startupcolors = "0092FF", "000000"
 startuptype = "Hexen"

--- a/DoomRPG/actors/Turret.txt
+++ b/DoomRPG/actors/Turret.txt
@@ -95,7 +95,7 @@ actor DRPGPortableTurret
     Missile.Bullet:
         PTUR A 0 A_SetUserVar("user_firing", 1)
         PTUR A 0 A_PlaySound("turret/fire", CHAN_WEAPON, 1.0, 0, 0.6)
-        PTUR B 0 Bright A_CustomBulletAttack(8, 0, 1, Random(5, 10) * (1 + user_bullet_damage) * (1 + (user_bullet_damage / (80 - user_bullet_damage * (1 + user_bullet_damage / 20)))), "BulletPuff", 0, CBAF_NORANDOM)
+        PTUR B 0 Bright A_CustomBulletAttack(8, 0, 1, Random(5, 10) * (1 + user_bullet_damage) * (1.0 + user_bullet_damage / 40.0), "BulletPuff", 0, CBAF_NORANDOM)
         PTUR A 0 ACS_NamedExecuteAlways("TurretUseAmmo", 0, TW_BULLET)
         PTUR B 2 Bright
         PTUR A 0 A_SetTics(6 - user_bullet_rof)
@@ -104,7 +104,7 @@ actor DRPGPortableTurret
     Missile.Pellet:
         PTUR A 0 A_SetUserVar("user_firing", 1)
         PTUR A 0 A_PlaySound("weapons/sshotf", CHAN_WEAPON, 1.0, 0, 0.6)
-        PTUR B 0 Bright A_CustomBulletAttack(16 - (user_pellet_spread * 3), 16 - (user_pellet_spread * 3), 3 * (user_pellet_amount + 1), Random(5, 10) * (1 + user_pellet_damage) * (1 + (user_pellet_damage / (80 - user_pellet_damage * (1 + user_pellet_damage / 20)))), "BulletPuff", 0, CBAF_NORANDOM)
+        PTUR B 0 Bright A_CustomBulletAttack(16 - (user_pellet_spread * 3), 16 - (user_pellet_spread * 3), 3 * (user_pellet_amount + 1), Random(5, 10) * (1 + user_pellet_damage) * (1.0 + user_pellet_damage / 40.0), "BulletPuff", 0, CBAF_NORANDOM)
         PTUR A 0 ACS_NamedExecuteAlways("TurretUseAmmo", 0, TW_PELLET)
         PTUR B 10 Bright
         PTUR A 0 A_SetTics(35 - (user_pellet_rof * 5))
@@ -128,7 +128,7 @@ actor DRPGPortableTurret
         Goto Spawn
     Missile.Railgun:
         PTUR A 0 A_SetUserVar("user_firing", 1)
-        PTUR E 0 Bright A_CustomRailgun(Random(50, 100) * (user_railgun_damage + 1), 0, "LightGreen", "Green", RGF_FULLBRIGHT | user_railgun_ripping, true, 0, "DRPGTurretRailgunPuff", 0, 0, 16384, 35 + (user_railgun_damage * 3), 1.0 - (user_railgun_damage / 20), 1.0 + (user_railgun_damage / 5), "None", -5)
+        PTUR E 0 Bright A_CustomRailgun(Random(50, 100) * (user_railgun_damage + 1) * (1.0 + user_railgun_damage / 40.0), 0, "LightGreen", "Green", RGF_FULLBRIGHT | user_railgun_ripping, true, 0, "DRPGTurretRailgunPuff", 0, 0, 16384, 35 + user_railgun_damage, 1.0 - (user_railgun_damage / 40.0), 1.0 + (user_railgun_damage / 10.0), "None", -5)
         PTUR A 0 ACS_NamedExecuteAlways("TurretUseAmmo", 0, TW_RAILGUN)
         PTUR E 10 Bright
         PTUR A 0 A_SetTics(35 - (user_plasma_rof * 5))
@@ -391,6 +391,66 @@ actor DRPGTurretProtectionMelee10 : PowerProtection
     Powerup.Duration 5
 }
 
+actor DRPGTurretProtectionMelee11 : PowerProtection
+{
+    DamageFactor "Melee", 0.475
+    Powerup.Duration 5
+}
+
+actor DRPGTurretProtectionMelee12 : PowerProtection
+{
+    DamageFactor "Melee", 0.45
+    Powerup.Duration 5
+}
+
+actor DRPGTurretProtectionMelee13 : PowerProtection
+{
+    DamageFactor "Melee", 0.425
+    Powerup.Duration 5
+}
+
+actor DRPGTurretProtectionMelee14 : PowerProtection
+{
+    DamageFactor "Melee", 0.4
+    Powerup.Duration 5
+}
+
+actor DRPGTurretProtectionMelee15 : PowerProtection
+{
+    DamageFactor "Melee", 0.375
+    Powerup.Duration 5
+}
+
+actor DRPGTurretProtectionMelee16 : PowerProtection
+{
+    DamageFactor "Melee", 0.35
+    Powerup.Duration 5
+}
+
+actor DRPGTurretProtectionMelee17 : PowerProtection
+{
+    DamageFactor "Melee", 0.325
+    Powerup.Duration 5
+}
+
+actor DRPGTurretProtectionMelee18 : PowerProtection
+{
+    DamageFactor "Melee", 0.3
+    Powerup.Duration 5
+}
+
+actor DRPGTurretProtectionMelee19 : PowerProtection
+{
+    DamageFactor "Melee", 0.275
+    Powerup.Duration 5
+}
+
+actor DRPGTurretProtectionMelee20 : PowerProtection
+{
+    DamageFactor "Melee", 0.25
+    Powerup.Duration 5
+}
+
 actor DRPGTurretProtectionBullet1 : PowerProtection
 {
     DamageFactor "Bullet", 0.95
@@ -448,6 +508,66 @@ actor DRPGTurretProtectionBullet9 : PowerProtection
 actor DRPGTurretProtectionBullet10 : PowerProtection
 {
     DamageFactor "Bullet", 0.5
+    Powerup.Duration 5
+}
+
+actor DRPGTurretProtectionBullet11 : PowerProtection
+{
+    DamageFactor "Bullet", 0.475
+    Powerup.Duration 5
+}
+
+actor DRPGTurretProtectionBullet12 : PowerProtection
+{
+    DamageFactor "Bullet", 0.45
+    Powerup.Duration 5
+}
+
+actor DRPGTurretProtectionBullet13 : PowerProtection
+{
+    DamageFactor "Bullet", 0.425
+    Powerup.Duration 5
+}
+
+actor DRPGTurretProtectionBullet14 : PowerProtection
+{
+    DamageFactor "Bullet", 0.4
+    Powerup.Duration 5
+}
+
+actor DRPGTurretProtectionBullet15 : PowerProtection
+{
+    DamageFactor "Bullet", 0.375
+    Powerup.Duration 5
+}
+
+actor DRPGTurretProtectionBullet16 : PowerProtection
+{
+    DamageFactor "Bullet", 0.35
+    Powerup.Duration 5
+}
+
+actor DRPGTurretProtectionBullet17 : PowerProtection
+{
+    DamageFactor "Bullet", 0.325
+    Powerup.Duration 5
+}
+
+actor DRPGTurretProtectionBullet18 : PowerProtection
+{
+    DamageFactor "Bullet", 0.3
+    Powerup.Duration 5
+}
+
+actor DRPGTurretProtectionBullet19 : PowerProtection
+{
+    DamageFactor "Bullet", 0.275
+    Powerup.Duration 5
+}
+
+actor DRPGTurretProtectionBullet20 : PowerProtection
+{
+    DamageFactor "Bullet", 0.25
     Powerup.Duration 5
 }
 
@@ -511,6 +631,66 @@ actor DRPGTurretProtectionFire10 : PowerProtection
     Powerup.Duration 5
 }
 
+actor DRPGTurretProtectionFire11 : PowerProtection
+{
+    DamageFactor "Fire", 0.475
+    Powerup.Duration 5
+}
+
+actor DRPGTurretProtectionFire12 : PowerProtection
+{
+    DamageFactor "Fire", 0.45
+    Powerup.Duration 5
+}
+
+actor DRPGTurretProtectionFire13 : PowerProtection
+{
+    DamageFactor "Fire", 0.425
+    Powerup.Duration 5
+}
+
+actor DRPGTurretProtectionFire14 : PowerProtection
+{
+    DamageFactor "Fire", 0.4
+    Powerup.Duration 5
+}
+
+actor DRPGTurretProtectionFire15 : PowerProtection
+{
+    DamageFactor "Fire", 0.375
+    Powerup.Duration 5
+}
+
+actor DRPGTurretProtectionFire16 : PowerProtection
+{
+    DamageFactor "Fire", 0.35
+    Powerup.Duration 5
+}
+
+actor DRPGTurretProtectionFire17 : PowerProtection
+{
+    DamageFactor "Fire", 0.325
+    Powerup.Duration 5
+}
+
+actor DRPGTurretProtectionFire18 : PowerProtection
+{
+    DamageFactor "Fire", 0.3
+    Powerup.Duration 5
+}
+
+actor DRPGTurretProtectionFire19 : PowerProtection
+{
+    DamageFactor "Fire", 0.275
+    Powerup.Duration 5
+}
+
+actor DRPGTurretProtectionFire20 : PowerProtection
+{
+    DamageFactor "Fire", 0.25
+    Powerup.Duration 5
+}
+
 actor DRPGTurretProtectionPlasma1 : PowerProtection
 {
     DamageFactor "Plasma", 0.95
@@ -568,6 +748,66 @@ actor DRPGTurretProtectionPlasma9 : PowerProtection
 actor DRPGTurretProtectionPlasma10 : PowerProtection
 {
     DamageFactor "Plasma", 0.5
+    Powerup.Duration 5
+}
+
+actor DRPGTurretProtectionPlasma11 : PowerProtection
+{
+    DamageFactor "Plasma", 0.475
+    Powerup.Duration 5
+}
+
+actor DRPGTurretProtectionPlasma12 : PowerProtection
+{
+    DamageFactor "Plasma", 0.45
+    Powerup.Duration 5
+}
+
+actor DRPGTurretProtectionPlasma13 : PowerProtection
+{
+    DamageFactor "Plasma", 0.425
+    Powerup.Duration 5
+}
+
+actor DRPGTurretProtectionPlasma14 : PowerProtection
+{
+    DamageFactor "Plasma", 0.4
+    Powerup.Duration 5
+}
+
+actor DRPGTurretProtectionPlasma15 : PowerProtection
+{
+    DamageFactor "Plasma", 0.375
+    Powerup.Duration 5
+}
+
+actor DRPGTurretProtectionPlasma16 : PowerProtection
+{
+    DamageFactor "Plasma", 0.35
+    Powerup.Duration 5
+}
+
+actor DRPGTurretProtectionPlasma17 : PowerProtection
+{
+    DamageFactor "Plasma", 0.325
+    Powerup.Duration 5
+}
+
+actor DRPGTurretProtectionPlasma18 : PowerProtection
+{
+    DamageFactor "Plasma", 0.3
+    Powerup.Duration 5
+}
+
+actor DRPGTurretProtectionPlasma19 : PowerProtection
+{
+    DamageFactor "Plasma", 0.275
+    Powerup.Duration 5
+}
+
+actor DRPGTurretProtectionPlasma20 : PowerProtection
+{
+    DamageFactor "Plasma", 0.25
     Powerup.Duration 5
 }
 

--- a/DoomRPG/scripts/Menu.c
+++ b/DoomRPG/scripts/Menu.c
@@ -2015,16 +2015,24 @@ void DrawTurretInfo(fixed X, fixed Y, int Index)
         Info = StrParam("\Ca%d", Player.Turret.HealthMax);
         break;
     case TU_ARMOR_PLATING_MELEE:
-        Info = StrParam("\Cc%d%%", Player.Turret.Upgrade[TU_ARMOR_PLATING_MELEE] * 5);
+        Info = StrParam("\Cc%.1k%%", Player.Turret.Upgrade[TU_ARMOR_PLATING_MELEE] * 5.0);
+        if (Player.Turret.Upgrade[TU_ARMOR_PLATING_MELEE] > 10)
+            Info = StrParam("\Cc%.1k%%", 50.0 + (Player.Turret.Upgrade[TU_ARMOR_PLATING_MELEE] - 10) * 2.5);
         break;
     case TU_ARMOR_PLATING_BULLET:
-        Info = StrParam("\Cj%d%%", Player.Turret.Upgrade[TU_ARMOR_PLATING_BULLET] * 5);
+        Info = StrParam("\Cj%.1k%%", Player.Turret.Upgrade[TU_ARMOR_PLATING_BULLET] * 5.0);
+        if (Player.Turret.Upgrade[TU_ARMOR_PLATING_BULLET] > 10)
+            Info = StrParam("\Cj%.1k%%", 50.0 + (Player.Turret.Upgrade[TU_ARMOR_PLATING_BULLET] - 10) * 2.5);
         break;
     case TU_ARMOR_PLATING_FIRE:
-        Info = StrParam("\Cg%d%%", Player.Turret.Upgrade[TU_ARMOR_PLATING_FIRE] * 5);
+        Info = StrParam("\Cg%.1k%%", Player.Turret.Upgrade[TU_ARMOR_PLATING_FIRE] * 5.0);
+        if (Player.Turret.Upgrade[TU_ARMOR_PLATING_FIRE] > 10)
+            Info = StrParam("\Cg%.1k%%", 50.0 + (Player.Turret.Upgrade[TU_ARMOR_PLATING_FIRE] - 10) * 2.5);
         break;
     case TU_ARMOR_PLATING_PLASMA:
-        Info = StrParam("\Cn%d%%", Player.Turret.Upgrade[TU_ARMOR_PLATING_PLASMA] * 5);
+        Info = StrParam("\Cn%.1k%%", Player.Turret.Upgrade[TU_ARMOR_PLATING_PLASMA] * 5.0);
+        if (Player.Turret.Upgrade[TU_ARMOR_PLATING_PLASMA] > 10)
+            Info = StrParam("\Cn%.1k%%", 50.0 + (Player.Turret.Upgrade[TU_ARMOR_PLATING_PLASMA] - 10) * 2.5);
         break;
     case TU_ARMOR_MODULE_PHASE:
         Y -= 4.0;

--- a/DoomRPG/scripts/Turret.c
+++ b/DoomRPG/scripts/Turret.c
@@ -86,7 +86,7 @@ TurretUpgrade RPGMap TurretUpgradeData[MAX_UPGRADES] =
         ""
     },
     {
-        "Weapon Module - Pellet - Amount", 10, 3,
+        "Weapon Module - Pellet - Amount", 5, 5,
         "Increases the number of pellets fired per shot",
         "",
         ""
@@ -100,7 +100,7 @@ TurretUpgrade RPGMap TurretUpgradeData[MAX_UPGRADES] =
         "Issuing this command will load the rocket weapon module"
     },
     {
-        "Weapon Module - Rocket - Damage", 10, 3,
+        "Weapon Module - Rocket - Damage", 20, 3,
         "Increases the damage of the turret's rockets",
         "",
         ""
@@ -132,7 +132,7 @@ TurretUpgrade RPGMap TurretUpgradeData[MAX_UPGRADES] =
         "Issuing this command will load the plasma weapon module"
     },
     {
-        "Weapon Module - Plasma - Damage", 10, 3,
+        "Weapon Module - Plasma - Damage", 20, 3,
         "Increases the damage of the turret's plasma shots",
         "",
         ""
@@ -158,7 +158,7 @@ TurretUpgrade RPGMap TurretUpgradeData[MAX_UPGRADES] =
         "Issuing this command will load the railgun weapon module"
     },
     {
-        "Weapon Module - Railgun - Damage", 10, 3,
+        "Weapon Module - Railgun - Damage", 20, 3,
         "Increases the damage of the turret's railgun shots",
         "",
         ""
@@ -231,25 +231,25 @@ TurretUpgrade RPGMap TurretUpgradeData[MAX_UPGRADES] =
         ""
     },
     {
-        "Armor Plating - Melee", 10, 5,
+        "Armor Plating - Melee", 20, 5,
         "Plating which protects against melee damage",
         "Upgrades increase protection amount",
         ""
     },
     {
-        "Armor Plating - Bullet", 10, 5,
+        "Armor Plating - Bullet", 20, 5,
         "Plating which protects against bullet damage",
         "Upgrades increase protection amount",
         ""
     },
     {
-        "Armor Plating - Fire", 10, 5,
+        "Armor Plating - Fire", 20, 5,
         "Plating which protects against fire damage",
         "Upgrades increase protection amount",
         ""
     },
     {
-        "Armor Plating - Plasma", 10, 5,
+        "Armor Plating - Plasma", 20, 5,
         "Plating which protects against plasma damage",
         "Upgrades increase protection amount",
         ""
@@ -286,10 +286,10 @@ TurretUpgrade RPGMap TurretUpgradeData[MAX_UPGRADES] =
     //
 
     {
-        "Battery - AUG Battery Adapter", 1, 5,
+        "Battery - AUG Battery Adapter", 1, 10,
         "Use turret from your AUG battery",
         "",
-        "issuing this command will toggle AUG Battery Adapter on and off"
+        "Issuing this command will toggle AUG Battery Adapter on and off"
     },
     {
         "Battery - Capacity", 10, 5,
@@ -941,9 +941,9 @@ NamedScript DECORATE int TurretGetProjectileDamage(int Type)
     SetActivator(GetActorProperty(0, APROP_MasterTID)); // Transfer from Turret to Player
 
     if (Type == TP_ROCKET)
-        return (100 * (Player.Turret.Upgrade[TU_WEAPON_ROCKET_DAMAGE] + 1));
+        return (100 * (Player.Turret.Upgrade[TU_WEAPON_ROCKET_DAMAGE] + 1) * (1.0 + Player.Turret.Upgrade[TU_WEAPON_ROCKET_DAMAGE] / 40.0));
     else if (Type == TP_PLASMA)
-        return (10 * (Player.Turret.Upgrade[TU_WEAPON_PLASMA_DAMAGE] + 1));
+        return (10 * (Player.Turret.Upgrade[TU_WEAPON_PLASMA_DAMAGE] + 1) * (1.0 + Player.Turret.Upgrade[TU_WEAPON_PLASMA_DAMAGE] / 40.0));
 
     return 0;
 }
@@ -1309,19 +1309,19 @@ Start:
             switch (Weapon)
             {
             case TW_BULLET:
-                HeatLevel += 5;
+                HeatLevel += 5 - (GetUserVariable(0, "user_bullet_rof") * 0.4);
                 break;
             case TW_PELLET:
-                HeatLevel += 15;
+                HeatLevel += 15 - (GetUserVariable(0, "user_pellet_rof") * 1.2);
                 break;
             case TW_ROCKET:
-                HeatLevel += 30;
+                HeatLevel += 30 - (GetUserVariable(0, "user_rocket_rof") * 2.4);
                 break;
             case TW_PLASMA:
-                HeatLevel += 8;
+                HeatLevel += 8 - (GetUserVariable(0, "user_plasma_rof") * 1.0);
                 break;
             case TW_RAILGUN:
-                HeatLevel += 50;
+                HeatLevel += 50 - (GetUserVariable(0, "user_railgun_rof") * 4.0);
                 break;
             }
         }
@@ -1624,7 +1624,7 @@ bool TurretLoadAmmo(int Type)
         "turret/reloadplasma",
         "turret/reloadrail"
     };
-    int MinAmount[5] = { 50, 20, 5, 100, 50 };
+    int MinAmount[5] = { 50, 20, 5, 100, 25 };
     int *Ammo[5] =
     {
         &Player.Turret.BulletAmmo,
@@ -1816,7 +1816,7 @@ void TurretCommand(int Index)
         if (!TurretLoadAmmo(TU_WEAPON_RAILGUN))
         {
             ActivatorSound("menu/error", 127);
-            PrintError("You need at least \Cd50 Cells\C- to load into the turret");
+            PrintError("You need at least \Cd25 Cells\C- to load into the turret");
         }
     }
 


### PR DESCRIPTION
Turret's balance changes:
- turret armor can now be upgraded to level 20 (melee, bullet, fire, plasma);
- turret weapon can now be upgraded to level 20 (rocket, plasma,railgun);
- now you need 25 cells instead of 50 cells to charge the turret's railgun;
- slightly increased time before CoolDown turret activation (when upgrading "Rate of Fire").