### PR TITLE
Update 1.31e

### DIFF
--- a/DoomRPG-RLArsenal-Extended/zscript/DRLAX/familiars/FamiliarBase.zscript
+++ b/DoomRPG-RLArsenal-Extended/zscript/DRLAX/familiars/FamiliarBase.zscript
@@ -1,0 +1,875 @@
+class DRLAX_FamiliarEvents : EventHandler
+{
+    override void WorldTick()
+    {
+        if(Level.Time == 2)
+        {
+            ThinkerIterator ti = ThinkerIterator.Create("DRLAX_FamiliarDataHolder", Thinker.STAT_STATIC);
+            DRLAX_FamiliarDataHolder p;
+            if(p = DRLAX_FamiliarDataHolder(ti.Next()))
+            {
+                p.Load();
+            }
+        }
+    }
+
+    override void WorldThingDestroyed(WorldEvent e)
+    {
+        Actor a = e.thing;
+        if(a && a.bISMONSTER && a.bCORPSE && !a.bFRIENDLY)
+        {  
+            ThinkerIterator ti = ThinkerIterator.Create("DRLAX_SkullUsed");
+            DRLAX_SkullUsed p;
+            uint ghostcount = 0;
+            if(p = DRLAX_SkullUsed(ti.Next()))
+            {
+                ThinkerIterator pti = ThinkerIterator.Create("PlayerPawn");
+                PlayerPawn player;
+                while(player = PlayerPawn(pti.Next()))
+                {
+                    if(player.CountInv("DRLAX_ArchvileFamiliarGhostCount") > 40)
+                    {
+                        break;
+                    }
+                    if(player.CountInv("DRLAX_ArchvileFamiliarPassive") > 0 && player.Distance2D(a) < 768 && a.CanRaise())
+                    {
+                        Actor ghost = Actor.Spawn(a.GetClassName(), a.pos);
+                        ghost.bFRIENDLY = true;
+                        ghost.species = "Player";
+                        ghost.A_SetTranslation("CMMDRLA_Ghost");
+                        ghost.GiveInventory("DRLAX_ArchvileFamiliarGhost", 1);
+                        ghost.bLOOKALLAROUND = true;
+                        ghost.lastheard = player;
+                        ghost.A_SetRenderStyle(0.7, STYLE_TRANSLUCENT);
+                        ghost.bTHRUSPECIES = true;
+                        player.GiveInventory("DRLAX_ArchvileFamiliarGhostCount", 1);
+                        break;
+                    }
+                }
+            }
+        }
+
+        if(a.GetClassName() == "RLUseHatredSkull" || a.GetClassName() == "RLUseBloodSkull" || a.GetClassName() == "RLUseFireSkull")
+        {
+            DRLAX_SkullUsed s = DRLAX_SkullUsed(new ("DRLAX_SkullUsed"));
+        }
+    }
+
+    override void WorldThingDied(WorldEvent e)
+    {
+        if(e.thing && e.thing.target)
+        {
+            if(e.thing.target.CountInv("DRLAX_RenegadeFamiliarPassive") > 0)
+            {
+                let f = DRLAX_RenegadeFamiliarPassive(e.thing.target.FindInventory("DRLAX_RenegadeFamiliarPassive"));
+                if(f)
+                {
+                    f.Trigger();
+                }
+            }
+
+            if(e.thing.target.CountInv("DRLAX_SpiderbotFamiliarPassive") > 0)
+            {
+                let f = DRLAX_SpiderbotFamiliarPassive(e.thing.target.FindInventory("DRLAX_SpiderbotFamiliarPassive"));
+                if(f)
+                {
+                    if(random(0, 12 - (f.power*2)) == 0)
+                    {
+                        String spid;
+                        Switch(random(0, 3))
+                        {
+                            Case 0: spid = "RLStandardSpiderCapsule"; break;
+                            Case 1: spid = "RLFirestormSpiderCapsule"; break;
+                            Case 2: spid = "RLSniperSpiderCapsule"; break;
+                            Case 3: spid = "RLNanoSpiderCapsule"; break;
+                        }
+                        bool spawned;
+                        Actor act;
+                        [spawned, act] = 
+                        e.thing.target.A_SpawnItemEx(spid, 0, 0, 4, frandom(-5, 5), frandom(-5, 5), 8, 
+                        flags:SXF_NOCHECKPOSITION);
+                        if(spawned && act)
+                        {
+                            act.SetOrigin(e.thing.pos, false);
+                        }
+                    }
+                }
+            }
+            
+        }
+
+        if(e.inflictor && e.thing && e.thing.bISMONSTER && e.inflictor is "DRLAX_FamiliarBase")
+        {
+            e.inflictor.GiveInventory("DRLAX_FamiliarKill", 1);
+        }
+    }
+
+    override void WorldThingSpawned (WorldEvent e)
+	{	
+        Actor a = e.thing;
+        if(a && a.target)
+        {
+            if((a.damagetype || a.damage > 0) && 
+            a.speed > 0 && 
+            a.bMISSILE && 
+            !a.bNOINTERACTION && 
+            a.bNOBLOCKMAP &&
+            a.Distance3D(a.target) < 50 &&
+            a.CountInv("DRLAX_CopiedProjectileInv") == 0)
+            {
+                let invc = a.target.CountInv("DRLAX_FatsoFamiliarPassive");
+                if(invc > 0 && random(0, 5 - invc) == 0)
+                {
+                    SpawnCopyMissile(a);
+                }
+
+                if(a is "Rocket")
+                {
+                    DRLAX_FamiliarManager f = DRLAX_FamiliarManager(a.target.FindInventory("DRLAX_FamiliarManager"));
+
+                    if(f)
+                    {
+                        for(int i; i<f.fam.Size(); i++)
+                        {
+                            DRLAX_SargeFamiliar sarge;
+
+                            if(f.fam[i] && f.fam[i] is "DRLAX_SargeFamiliar")
+                            {
+                                sarge = DRLAX_SargeFamiliar(f.fam[i]);
+                                //if( sarge.Distance3D(a.target)>50)
+                                //{
+                                    sarge.firedm = a.GetClassName();
+                                //}
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        if(a && a.GetclassName() == "TeleportFog")
+        {
+            if(a.target && a.target.health > 0)
+            {
+                if(a.target.CountInv("DRLAX_TerriFamiliarPassive") > 0)
+                {
+                    a.target.GiveInventory("DRLAX_TerriFamiliarPowerup", 1);
+                }
+
+                if(a.target.CountInv("DRLAX_PortiaFamiliarPassive") > 0)
+                {
+                    a.target.GiveInventory("DRLAX_PortiaFamiliarPowerup", 1);
+                }
+            }
+        }
+    }
+
+    void SpawnCopyMissile(Actor a)
+    {
+        Actor copy = Actor.Spawn(a.GetClassName(), a.pos);
+        copy.target = a.target;
+        copy.tracer = a.tracer;
+        copy.vel = a.vel;
+        copy.angle = a.angle;
+        copy.pitch = a.pitch;
+        copy.GiveInventory("DRLAX_CopiedProjectileInv", 1);
+        copy.A_ChangeVelocity(0, -3 + (random(0,1) * 5), 0, CVF_RELATIVE);
+    }
+}
+
+class DRLAX_SkullUsed : Thinker
+{
+    override void Tick()
+    {
+        Destroy();
+    }
+}
+
+class DRLAX_CopiedProjectileInv : Inventory {}
+
+class DRLAX_FamiliarBase : Actor
+{
+    Default
+    {
+        +NOINTERACTION;
+        +NOGRAVITY;
+        +PAINLESS;
+        +MISSILE;
+        +THRUSPECIES;
+        +MTHRUSPECIES;
+        +NOTIMEFREEZE;
+        species "Player";
+        scale 0.25;
+        radius 1;
+        height 1;
+        translation "CMMDRLA_Familiar";
+        renderstyle "Style_Translucent";
+        alpha 0.95;
+    }
+
+    uint attackcooldown;
+    Actor playeractor;
+    Actor tofollow;
+
+    states
+    {
+        Spawn:
+        PLAY ABCD 8 FamiliarIdle();
+        loop;
+        Missile:
+        PLAY F 2;
+        PLAY G 2 bright;
+        PLAY F 2;
+        Goto Spawn;
+    }
+
+    Vector3 ppos;
+    DRLAX_FamiliarPlatform plat; 
+
+    virtual void MoveToPlatform()
+    {
+        SetOrigin(plat.pos, true);
+    }
+
+    virtual void FamiliarTick()
+    {
+        MoveToPlatform();
+    }
+    
+    virtual void FamiliarStart()
+    {
+    }
+
+    virtual void FamiliarEnd()
+    {
+    }
+
+    override void OnDestroy()
+    {
+        if(playeractor)
+        {
+            FamiliarEnd();
+        }
+        Super.OnDestroy();
+    }
+
+    uint idletimer;
+
+    virtual void FamiliarIdle()
+    {
+        if(!tracer || tracer && tracer.health < 1)
+        {
+            tracer = null;
+            idletimer++;
+
+            if(idletimer == 9)
+            {
+                angle = random(0,360);
+                idletimer = 0;
+            }
+        }
+
+        if(tracer)
+        {
+            FamiliarAction();
+            A_Face(tracer);
+        }
+        else
+        {
+            if(GetAge() % 35 == 0)
+            {
+                FindNewTracer();
+                if(tracer)
+                {
+                    if(!tracer.target || tracer.target != playeractor)
+                    {
+                        tracer = null;
+                    }
+                }
+            }
+        }
+    }
+
+    virtual void FamiliarAction()
+    {
+        SetStateLabel("Missile");
+    }
+
+    override void Tick()
+    {
+        if(attackcooldown > 0)
+        {
+            attackcooldown--;
+            if(attackcooldown > 70)
+            {
+                plat.A_SetTranslation("CMMDRLA_Red");
+            }
+            if(attackcooldown < 70)
+            { 
+                plat.A_SetTranslation("CMMDRLA_Orange");
+            }
+            if(attackcooldown < 10)
+            { 
+                plat.A_SetTranslation("");
+            }
+        }
+
+        if(GetAge() % (35*3) == 0)
+        {
+            if(tracer)
+            {
+                if(Distance2D(tracer) > 2000 && !CheckSight(tracer))
+                {
+                    tracer = null;
+                }
+            }
+        }
+
+        if(!plat)
+        {
+            plat = DRLAX_FamiliarPlatform(Spawn("DRLAX_FamiliarPlatform", pos));
+            plat.target = self;
+            plat.reactiontime = radius;
+        }
+        if(tofollow && plat && plat.Distance3D(target) > 90)
+        {
+            uint h = 0;
+            if(tofollow.player)
+            {
+               h = 38;
+            }
+
+            DRLAX_FamiliarBase f = DRLAX_FamiliarBase(tofollow);
+            if(f)
+            {
+                ppos = f.plat.pos + (0, 0, h);
+            }
+            else
+            {
+                ppos = tofollow.pos + (0, 0, h);
+            }
+        }
+
+        //Console.Printf("" .. Level.Time * 0.0001);
+        Vector3 newpos = Vec3Lerp(plat.pos, ppos, 0.05);
+        //newpos = ppos;
+        plat.SetOrigin(newpos, true);
+        
+        FamiliarTick();
+        if(GetAge() < 8)
+        {
+            A_SpawnItemEx("RLDemonicBossTeleportFogSpark", 0,0,0, frandom(-1.0,1.0),frandom(-1.0,1.0),frandom(-1.0,1.0), 0, SXF_NOCHECKPOSITION);
+        }
+
+        int dist;
+        
+        if(playeractor)
+        {
+            dist = Distance2D(playeractor);
+        }
+
+        if(playeractor && playeractor.player.cmd.buttons & BT_USE && dist <= 8)
+        {
+            ShowDescription(playeractor);
+        }
+
+        if(dist < 64)
+        {
+            A_SetRenderStyle(Clamp(dist * 0.02, 0.01, 0.95), Style_Translucent);
+        }
+        else if (alpha < 0.95)
+        {
+            A_SetRenderStyle(0.95, Style_Translucent);
+        }
+
+        Super.Tick();
+    }
+
+    vector3 Vec3Lerp(vector3 a, vector3 b, double t)
+    {	
+		if(t < 0){t = 0;}
+		else if (t > 1.0)
+		{
+			t = 1.0;
+		}
+
+        return (a.x + (b.x - a.x) * t,
+                a.y + (b.y - a.y) * t,
+                a.z + (b.z - a.z) * t);
+    }
+
+    void FamiliarLineAttack(double angle, double pitch, int damage, name damagetype, Class<Actor> puff, bool usepain)
+    {
+        if(usepain)
+        {
+            LineAttack(angle, 5000, pitch, damage, damagetype, puff, LAF_TARGETISSOURCE);
+            return;
+        }
+        FTranslatedLineTarget victim;
+        LineAttack(angle, 5000, pitch, 0, damagetype, puff, LAF_TARGETISSOURCE, victim);
+
+        if(victim.linetarget && victim.linetarget != playeractor)
+        {
+            victim.linetarget.DamageMobj(self, playeractor, damage, damagetype, DMG_NO_PAIN);
+            //Console.PRintf("victim " .. victim.linetarget.getclassname());
+        }
+    }
+
+    void FindNewTracer()
+    {
+        tracer = null;
+        A_SeekerMissile(90, 90, SMF_LOOK, 256, 64);
+        if(tracer)
+        {
+            if((playeractor && tracer == playeractor) || Distance2D(tracer) > 1000)
+            {
+                tracer = null;
+            }
+        }
+    }
+
+    override void PostBeginPlay()
+    {
+        if(!target || (!playeractor || playeractor.CountInv("DRLAX_FamiliarManager") == 0))
+        {
+            Destroy();
+            return;
+        }
+    }
+
+    void ShowDescription(Actor other)
+    {
+        String c = GetClassName();
+        c.Replace("DRLAX_", "");
+        c.ToUpper();
+        String s = Stringtable.Localize("$" .. "TXT_" .. c);
+        other.A_Print(s, 5.0);
+    }
+    
+    void GiveStackingPassive(Class<DRLAX_FamiliarPassive> passive, bool addorremove)
+    {
+        DRLAX_FamiliarPassive p = DRLAX_FamiliarPassive(playeractor.FindInventory(passive));
+
+        if(addorremove)
+        {
+            if(p)
+            {
+                //Console.Printf("found inv, adding power");
+                p.power++;
+            }
+            else
+            {
+                //Console.Printf("no inv, giving passive");
+                playeractor.GiveInventory(passive, 1);
+            }
+        }
+        else
+        {
+            //Console.Printf("we are removing");
+            if(p)
+            {
+                if(p.power > 0)
+                {
+                    p.power--;
+                }
+                else
+                {
+                    playeractor.TakeInventory(passive, 1);
+                    //Console.Printf("removed!");
+                }
+            }
+        }  
+    }
+}
+
+class DRLAX_FamiliarPlatform : Actor
+{
+    Default
+    {
+        +NOINTERACTION;
+        +NOGRAVITY;
+        +NOTIMEFREEZE;
+        height 1;
+        radius 1;
+    }
+
+    states
+    {
+        Spawn:
+        TNT1 A -1;
+        stop;
+    }
+
+    override void PostBeginPlay()
+    {
+        for(int i; i<3; i++)
+        {
+            DRLAX_FamiliarPlatformParticle p = DRLAX_FamiliarPlatformParticle(Spawn("DRLAX_FamiliarPlatformParticle"));
+            p.reactiontime = i;
+            p.target = self;
+        }
+    }
+
+    override void Tick()
+    {
+        angle += 5;
+        if(!target)
+        {
+            Destroy();
+            return;
+        }
+        Super.Tick();
+    }
+}
+
+class DRLAX_FamiliarPlatformParticle : Actor
+{
+    Default
+    {
+        +NOINTERACTION;
+        +NOGRAVITY;
+        +NOTIMEFREEZE;
+        +BRIGHT;
+        height 1;
+        radius 1;
+        scale 0.25;
+    }
+
+    states
+    {
+        Spawn:
+        AEFG GHIJIH 2;
+        loop;
+    }
+
+    override void Tick()
+    {
+        if(!target)
+        {
+            Destroy();
+            return;
+        }
+
+        Warp(target, 8 + target.reactiontime, 0, 0, reactiontime * 120, WARPF_COPYINTERPOLATION|WARPF_NOCHECKPOSITION);
+        translation = target.translation;
+        float trans = Cvar.GetCvar("DRLAX_familiarplatformtrans", Players[consoleplayer]).GetFloat();
+        A_SetTranslucent(trans);
+
+        Super.Tick();
+    }
+}
+
+class DRLAX_FamiliarDataHolder : Thinker
+{
+    Class<Actor> familiars[5];
+    uint playerno;
+
+    void Save(DRLAX_FamiliarManager f)
+    {
+        for(int i; i<5; i++)
+        {
+            familiars[i] = f.familiars[i];
+        }
+        playerno = f.owner.PlayerNumber();
+        ChangeStatNum(STAT_STATIC);
+    }
+
+    void Load()
+    {
+        DRLAX_FamiliarManager fm = DRLAX_FamiliarManager(Actor.Spawn("DRLAX_FamiliarManager"));
+        fm.AttachToOwner(players[playerno].mo);
+
+        for(int i; i<5; i++)
+        {
+            fm.familiars[i] = familiars[i];
+        }
+
+        fm.Init();
+        Destroy();
+    }
+}
+
+
+class DRLAX_FamiliarManager : Inventory
+{
+    Default
+    {
+		+INVENTORY.UNDROPPABLE;
+		+INVENTORY.UNTOSSABLE;
+    }
+
+    DRLAX_FamiliarBase fam[5];
+    Class<Actor> familiars[5];
+
+    DRLAX_FamiliarBase FindFamiliar(String famname)
+    {
+        for(int i; i<fam.Size(); i++)
+        {
+            if(fam[i] && fam[i].GetClassName() == famname)
+            {
+                return fam[i];
+            }
+        }
+
+        return null;
+    }
+
+    Class<DRLAX_FamiliarBase> GetRandomFamiliar()
+    {
+        Array<Class<DRLAX_FamiliarBase> > fams;
+        for(int i; i<AllActorClasses.Size(); i++)
+        {
+            if(AllActorClasses[i] is "DRLAX_FamiliarBase")
+            {
+                if(AllActorClasses[i].GetClassName() == "DRLAX_FamiliarBase")
+                {
+                    continue;
+                }
+
+                fams.Push(AllActorClasses[i]);
+            }
+        }
+
+        if(fams.Size() > 0)
+        {
+            return fams[random(0,fams.Size()-1)];
+        }
+
+        return null;
+    }
+
+    static bool NewFamiliar(Actor other, Class<DRLAX_FamiliarBase> f)
+    {
+        DRLAX_FamiliarManager fm = DRLAX_FamiliarManager(other.FindInventory("DRLAX_FamiliarManager"));
+
+        if(!fm)
+        {
+            fm = DRLAX_FamiliarManager(other.Spawn("DRLAX_FamiliarManager"));
+            fm.AttachToOwner(other);
+            fm.Init();
+        }
+
+        return (fm.AddFamiliar(f));
+    }
+
+    override void Tick()
+    {
+        if(!owner || owner.health < 1)
+        {
+            Super.Tick();
+            return;
+        }
+
+        SyncTargets();
+
+        Super.Tick();
+    }
+
+    void SyncTargets()
+    {
+        for(int i; i<5; i++)
+        {
+            if(fam[i])
+            {
+                if(i == 0)
+                {
+                    fam[i].tofollow = owner;
+                }
+                else
+                {
+                    fam[i].tofollow = fam[i - 1];
+                }
+
+                fam[i].playeractor = owner;
+            }
+        }
+    }
+
+    virtual void Init()
+    {
+        for(int i; i<5; i++)
+        {
+            if(familiars[i])
+            {
+                SpawnFamiliar(i);
+            }
+        }
+    }
+
+    bool AddFamiliar(Class<DRLAX_FamiliarBase> f)
+    {
+        for(int i; i<5; i++)
+        {
+            if(!familiars[i])
+            {
+                familiars[i] = f;
+                Init();
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    void SpawnFamiliar(int slot)
+    {
+        if(!fam[slot] && familiars[slot])
+        {
+            if(familiars[slot] == "DRLAX_NanoManiacFamiliar" && Level.Time < 50)
+            {
+                fam[slot] = DRLAX_FamiliarBase(owner.Spawn(GetRandomFamiliar(), owner.pos + (0,0,32)));
+            }
+            else
+            {
+                fam[slot] = DRLAX_FamiliarBase(owner.Spawn(familiars[slot], owner.pos + (0,0,32)));
+            }
+            SyncTargets();
+            fam[slot].FamiliarStart();
+            fam[slot].A_StartSound(fam[slot].seesound, CHAN_VOICE, pitch:1.25);
+            fam[slot].target = owner;
+            if(Cvar.GetCvar("DRLAX_nofamiliartint", owner.player).GetBool()) 
+            {
+                fam[slot].A_SetTranslation("");
+            }
+
+            fam[slot].ACS_NamedExecuteAlways("FamiliarInit", 0, owner.PlayerNumber(), slot);
+        }
+    }
+
+    override void ModifyDamage (int damage, Name damageType, out int newdamage, bool passive, Actor inflictor, Actor source, int flags)
+    {
+        if (!passive && damage > 0 && source && source.health > 0 && source.bISMONSTER)
+        {
+            for(int i; i<fam.Size(); i++)
+            {
+                if(fam[i])
+                {
+                    fam[i].tracer = source;
+                }
+            }
+        }
+    }
+
+    static void RemoveFamiliar(actor other, int slot)
+    {
+        DRLAX_FamiliarManager fm = DRLAX_FamiliarManager(other.FindInventory("DRLAX_FamiliarManager"));
+
+        if(!fm)
+        {
+            return;
+        }
+
+        if(fm.familiars[slot])
+        {
+            fm.familiars[slot] = null;
+            //fm.fam[slot].FamiliarEnd(); // called by ondestroy
+            fm.fam[slot].Destroy();
+            for(int i = slot; i<5; i++)
+            {
+                if(fm.fam[i])
+                {
+                    fm.fam[i-1] = fm.fam[i];
+                    fm.fam[i] = null;
+                    fm.familiars[i-1] = fm.familiars[i];
+                    fm.familiars[i] = null;
+                }
+            }
+        }
+
+        fm.SyncTargets();
+    }
+
+    static void DRPGRemoveFamiliar(int playernum, int slot)
+    {
+        DRLAX_FamiliarManager fm = DRLAX_FamiliarManager(Players[playernum].mo.FindInventory("DRLAX_FamiliarManager"));
+
+        if(!fm)
+        {
+            return;
+        }
+
+        if(fm.familiars[slot])
+        {
+            fm.familiars[slot] = null;
+            fm.fam[slot].Destroy();
+        }
+
+        fm.SyncTargets();
+    }
+
+    override void PreTravelled()
+    {
+        DRLAX_FamiliarDataHolder fm = new("DRLAX_FamiliarDataHolder");
+        fm.Save(self);
+        Destroy();
+    }
+
+}
+
+class DRLAX_FamiliarProjectile : FastProjectile
+{
+    Default
+    {
+        Radius 6;
+        Height 7;
+        species "Player";
+        scale 0.35;
+        PROJECTILE;
+        +PAINLESS;
+        +DONTREFLECT;
+    }
+}
+
+class DRLAX_FamiliarKill : Inventory
+{
+    Default
+    {
+        inventory.maxamount 99999;
+		+INVENTORY.UNDROPPABLE;
+		+INVENTORY.UNTOSSABLE;
+    }
+}
+
+class DRLAX_FamiliarPassive : Inventory
+{
+    uint power;
+
+    Default
+    {
+        inventory.maxamount 6;
+        +INVENTORY.UNDROPPABLE;
+		+INVENTORY.UNTOSSABLE;
+    }
+}
+
+
+Class TestFamiliar : Inventory
+{
+    override void AttachToOwner(actor other)
+    {
+        DRLAX_FamiliarManager.NewFamiliar(other, "DRLAX_NomadFamiliar");
+        Destroy();
+        return;
+    }
+}
+
+
+Class TestFamiliar2 : Inventory
+{
+    override void AttachToOwner(actor other)
+    {
+        DRLAX_FamiliarManager.NewFamiliar(other, "DRLAX_MechanoidFamiliar");
+        Destroy();
+        return;
+    }
+}
+
+Class TestFamiliar3 : Inventory
+{
+    override void AttachToOwner(actor other)
+    {
+        DRLAX_FamiliarManager.RemoveFamiliar(other, 1);
+        Destroy();
+        return;
+    }
+}

--- a/DoomRPG-RLArsenal/actors/doomrl/Health.txt
+++ b/DoomRPG-RLArsenal/actors/doomrl/Health.txt
@@ -4,6 +4,9 @@ actor RLHealthBonusRPG : DRPGHealthBonus Replaces RLHealthBonus {}
 // Stimpack
 actor RLStimpackRPG : DRPGStimpack Replaces RLStimpack {}
 
+// Medikit
+actor RLMedikitRPG : DRPGMedikit Replaces RLMedikit {}
+
 // Soulspheres
 ACTOR RLSoulsphere2 : DRPGSoulsphere replaces DRPGSoulsphere
 {

--- a/DoomRPG/GAMEINFO.txt
+++ b/DoomRPG/GAMEINFO.txt
@@ -1,3 +1,3 @@
-startuptitle = "Doom RPG SE Rebalance (2023-03-06)"
+startuptitle = "Doom RPG SE Rebalance (2023-03-07)"
 startupcolors = "0092FF", "000000"
 startuptype = "Hexen"

--- a/DoomRPG/scripts/Monsters.c
+++ b/DoomRPG/scripts/Monsters.c
@@ -3853,6 +3853,27 @@ fixed MapTotalBossesMod()
     return MapTotalBossesMod;
 }
 
+// Compatibility Handling - DoomRL Arsenal Extended
+// Familiar Init Script
+NamedScript DECORATE void FamiliarInit(int PlayerNum, int Slot)
+{
+    // Get a new ID for the familiar
+    if (GetMonsterID(0) == 0)
+        SetMonsterID(0, NewMonsterID());
+
+    // Store TID
+    if (ActivatorTID() == 0)
+    {
+        int TID = UniqueTID();
+        Thing_ChangeTID(0, TID);
+        Players(PlayerNum).FamiliarTID[Slot] = TID;
+    }
+    else
+        Players(PlayerNum).FamiliarTID[Slot] = ActivatorTID();
+
+    Players(PlayerNum).Familiars = true;
+}
+
 NamedScript DECORATE int GetMonsterHealthMax()
 {
     // Pointer

--- a/DoomRPG/scripts/Outpost.c
+++ b/DoomRPG/scripts/Outpost.c
@@ -2383,6 +2383,7 @@ NamedScript MapSpecial void DisassemblingDevice()
                 int CostMin;
                 int CostMax;
                 int CurrentExtraction;
+                int CurrentExtractionCost;
 
                 // Chances of getting parts
                 int MaxAmount;
@@ -2671,6 +2672,9 @@ NamedScript MapSpecial void DisassemblingDevice()
                         ChanceDetails = 100.0 -  ChanceChips - ChanceBattery - ChanceTurret - ChanceBluePrint - ChanceModPacks - ChanceModule - ChanceAug;
                     }
 
+                    // Calculate Current Extraction Cost
+                    CurrentExtractionCost = (25 * MaxAmount - (25 * MaxAmount * Player.ShopDiscount / 100)) / 5 * 5;
+
                     // Text
                     SetFont("BIGFONT");
                     HudMessage("\CdDisassembling Device\C-");
@@ -2710,10 +2714,21 @@ NamedScript MapSpecial void DisassemblingDevice()
                         HudMessage("%S", ExtentExtraction[CurrentExtraction]);
                         EndHudMessage(HUDMSG_FADEOUT, MENU_ID + 6, "White", X + 304.0, Y + 304.0, 0.05, 0.05);
 
+                        SetFont("SMALLFONT");
+                        HudMessage("Cost of Extraction:");
+                        EndHudMessage(HUDMSG_FADEOUT, MENU_ID + 7, "White", X + 288.0, Y + 336.0, 0.05, 0.05);
+
+                        SetFont("BIGFONT");
+                        HudMessage("\Cf%d C\C-", CurrentExtractionCost);
+                        EndHudMessage(HUDMSG_FADEOUT, MENU_ID + 8, "White", X + 336.0, Y + 368.0, 0.05, 0.05);
+
+                        SetFont("SMALLFONT");
+                        HudMessage("\Ck(Discount: %d%%)", Player.ShopDiscount);
+                        EndHudMessage(HUDMSG_FADEOUT, MENU_ID + 9, "White", X + 304.0, Y + 400.0, 0.05, 0.05);
 
                         SetFont("SMALLFONT");
                         HudMessage("Possible Extraction:\n\nMaximum amount: \Cd%d pcs.\C-", MaxAmount);
-                        EndHudMessage(HUDMSG_FADEOUT, MENU_ID + 7, "White", X + 32.0, Y + 272.0, 0.05, 0.05);
+                        EndHudMessage(HUDMSG_FADEOUT, MENU_ID + 10, "White", X + 32.0, Y + 272.0, 0.05, 0.05);
 
                         // Possible Extraction
                         // For Details
@@ -2721,56 +2736,56 @@ NamedScript MapSpecial void DisassemblingDevice()
                         {
                             SetFont("SMALLFONT");
                             HudMessage("\CdDetails\C- rate: \Cf%.2k%%\C-", ChanceDetails);
-                            EndHudMessage(HUDMSG_FADEOUT, MENU_ID + 8, "White", X + 32.0, Y + 280.0 + 24.0, 0.05, 0.05);
+                            EndHudMessage(HUDMSG_FADEOUT, MENU_ID + 11, "White", X + 32.0, Y + 280.0 + 24.0, 0.05, 0.05);
                         }
                         // For Chips
                         if (ChanceChips > 0)
                         {
                             SetFont("SMALLFONT");
                             HudMessage("\CfChips\C- rate: \Cf%.2k%%\C-", ChanceChips);
-                            EndHudMessage(HUDMSG_FADEOUT, MENU_ID + 9, "White", X + 32.0, Y + 280.0 + 32.0, 0.05, 0.05);
+                            EndHudMessage(HUDMSG_FADEOUT, MENU_ID + 12, "White", X + 32.0, Y + 280.0 + 32.0, 0.05, 0.05);
                         }
                         // For Recipes
                         if (ChanceBluePrint > 0)
                         {
                             SetFont("SMALLFONT");
                             HudMessage("\CnRecipes\C- rate: \Cf%.2k%%\C-", ChanceBluePrint);
-                            EndHudMessage(HUDMSG_FADEOUT, MENU_ID + 10, "White", X + 32.0, Y + 280.0 + 40.0, 0.05, 0.05);
+                            EndHudMessage(HUDMSG_FADEOUT, MENU_ID + 13, "White", X + 32.0, Y + 280.0 + 40.0, 0.05, 0.05);
                         }
                         // For Battery
                         if (ChanceBattery > 0)
                         {
                             SetFont("SMALLFONT");
                             HudMessage("\CaBattery\C- rate: \Cf%.2k%%\C-", ChanceBattery);
-                            EndHudMessage(HUDMSG_FADEOUT, MENU_ID + 11, "White", X + 32.0, Y + 280.0 + 48.0, 0.05, 0.05);
+                            EndHudMessage(HUDMSG_FADEOUT, MENU_ID + 14, "White", X + 32.0, Y + 280.0 + 48.0, 0.05, 0.05);
                         }
                         // For Turret Parts
                         if (ChanceTurret > 0)
                         {
                             SetFont("SMALLFONT");
                             HudMessage("\CgTurret Parts\C- rate: \Cf%.2k%%\C-", ChanceTurret);
-                            EndHudMessage(HUDMSG_FADEOUT, MENU_ID + 12, "White", X + 32.0, Y + 280.0 + 56.0, 0.05, 0.05);
+                            EndHudMessage(HUDMSG_FADEOUT, MENU_ID + 15, "White", X + 32.0, Y + 280.0 + 56.0, 0.05, 0.05);
                         }
                         // For ModPacks
                         if (ChanceModPacks > 0)
                         {
                             SetFont("SMALLFONT");
                             HudMessage("\CrModPacks\C- rate: \Cf%.2k%%\C-", ChanceModPacks);
-                            EndHudMessage(HUDMSG_FADEOUT, MENU_ID + 13, "White", X + 32.0, Y + 280.0 + 64.0, 0.05, 0.05);
+                            EndHudMessage(HUDMSG_FADEOUT, MENU_ID + 16, "White", X + 32.0, Y + 280.0 + 64.0, 0.05, 0.05);
                         }
                         // For Module
                         if (ChanceModule > 0)
                         {
                             SetFont("SMALLFONT");
                             HudMessage("\CqModule\C- rate: \Cf%.2k%%\C-", ChanceModule);
-                            EndHudMessage(HUDMSG_FADEOUT, MENU_ID + 14, "White", X + 32.0, Y + 280.0 + 72.0, 0.05, 0.05);
+                            EndHudMessage(HUDMSG_FADEOUT, MENU_ID + 17, "White", X + 32.0, Y + 280.0 + 72.0, 0.05, 0.05);
                         }
                         // For Augmentation
                         if (ChanceAug > 0)
                         {
                             SetFont("SMALLFONT");
                             HudMessage("\CkAugmentation\C- rate: \Cf%.2k%%\C-", ChanceAug);
-                            EndHudMessage(HUDMSG_FADEOUT, MENU_ID + 15, "White", X + 32.0, Y + 280.0 + 80.0, 0.05, 0.05);
+                            EndHudMessage(HUDMSG_FADEOUT, MENU_ID + 18, "White", X + 32.0, Y + 280.0 + 80.0, 0.05, 0.05);
                         }
                     }
                     else
@@ -2811,7 +2826,7 @@ NamedScript MapSpecial void DisassemblingDevice()
                     {
                         if (CheckInput(BT_SPEED, KEY_HELD, false, PlayerNumber()))
                         {
-                            if (CurrentCategory == 0 && WeaponData > 0 || CurrentCategory == 1 && ArmorData > 0 || CurrentCategory == 2 && ShieldData > 0)
+                            if (CheckInventory("DRPGCredits") >= CurrentExtractionCost && (CurrentCategory == 0 && WeaponData > 0 || CurrentCategory == 1 && ArmorData > 0 || CurrentCategory == 2 && ShieldData > 0))
                             {
                                 Player.OutpostMenu = 0;
                                 str ActorToSpawn;
@@ -2820,8 +2835,11 @@ NamedScript MapSpecial void DisassemblingDevice()
                                 int AddMenuID = 4;
                                 fixed Y1;
 
+                                // Take Current Extraction Cost
+                                TakeInventory("DRPGCredits", CurrentExtractionCost);
+
                                 // Take Current Item
-                                TakeInventory(CurrentActor,1);
+                                TakeInventory(CurrentActor, 1);
 
                                 // Take tokens from DoomRL Arsenal
                                 if (CompatMode == COMPAT_DRLA);
@@ -3201,7 +3219,15 @@ NamedScript MapSpecial void DisassemblingDevice()
                                 return;
                             }
                             else
+                            {
+                                SetFont("BIGFONT");
+                                if (CurrentCategory == 0 && WeaponData <= 0 || CurrentCategory == 1 && ArmorData <= 0 || CurrentCategory == 2 && ShieldData <= 0)
+                                    PrintError("Item is not selected for disassembly");
+                                else if (CheckInventory("DRPGCredits") < CurrentExtractionCost)
+                                    PrintError("Not enough credits to disassemble this item");
+
                                 ActivatorSound("menu/error", 127);
+                            }
                         }
                     }
                     Delay(1);

--- a/DoomRPG/scripts/Skills.c
+++ b/DoomRPG/scripts/Skills.c
@@ -2496,6 +2496,28 @@ NamedScript Console bool Rally(SkillLevelInfo *SkillLevel, void *Data)
 
 NamedScript Console bool Unsummon(SkillLevelInfo *SkillLevel, void *Data)
 {
+    // Compatibility Handling - DoomRL Arsenal Extended
+    if (CompatModeEx == COMPAT_DRLAX && Player.Overdrive)
+    {
+        // Fail if you have no familiars active
+        if (!Player.Familiars)
+        {
+            PrintError("You have no familiars");
+            ActivatorSound("menu/error", 127);
+            return false;
+        }
+
+        // Remove familiars
+        for (int j = 0; j < MAX_FAMILIARS; j++)
+            ScriptCall("DRLAX_FamiliarManager", "DRPGRemoveFamiliar", PlayerNumber(), j);
+
+        Player.Familiars = false;
+
+        FadeRange(192, 0, 0, 0.5, 192, 0, 0, 0.0, 1.0);
+        ActivatorSound("skills/unsummon", 127);
+        return true;
+    }
+
     int EPAdd;
 
     // Fail if you have no summons active
@@ -2525,10 +2547,11 @@ NamedScript Console bool Unsummon(SkillLevelInfo *SkillLevel, void *Data)
         Player.SummonTID[i] = 0;
     }
 
-
-    Log("EPAdd: %d", EPAdd);
     if (SkillLevel->CurrentLevel == 2)
+    {
         Player.EP += EPAdd;
+        Log("EPAdd: %d", EPAdd);
+    }
 
     Player.Summons = 0;
 
@@ -3381,6 +3404,7 @@ void CheckSkills()
     else
         Skills[5][5].Cost = 25;
 
+    // Compatibility Handling - DoomRL Arsenal
     // Summoning Skills - Marines Descriptions
     if (CompatMode == COMPAT_DRLA)
     {
@@ -3477,6 +3501,13 @@ void CheckSkills()
         {
             Skills[4][0].Description[7] = "BFG 10000";
         }
+    }
+
+    // Compatibility Handling - DoomRL Arsenal Extended
+    if (CompatModeEx == COMPAT_DRLAX)
+    {
+        Skills[5][3].Description[0] = "Banishes all of the friendly creatures under your control\n\n\CiOverdrive\C-:\nBanishes all of the familiars under your control";
+        Skills[5][3].Description[1] = "Banishes all of the friendly creatures under your control\nEach creature banished restores \Cn1% EP\C-\n\n\CiOverdrive\C-:\nBanishes all of the familiars under your control";
     }
 
     // Reset the Skill refund multiplier from the Blue Aura and Energy Augmentation

--- a/DoomRPG/scripts/Stats.c
+++ b/DoomRPG/scripts/Stats.c
@@ -538,13 +538,28 @@ void CheckStats()
     Player.ToxicityRegenBonus = Player.RegenerationTotal / 10;
     Player.JumpHeight = 8.0 + (8.0 * ((fixed)Player.AgilityTotal / 100));
     Player.WeaponSpeed = Player.AgilityTotal / 2;
-    SetAmmoCapacity("Clip", (int)(115 + Player.CapacityTotal * 7.5) / 10 * 10);
-    SetAmmoCapacity("Shell", 20 + Player.CapacityTotal * 2);
-    SetAmmoCapacity("RocketAmmo", 5 + Player.CapacityTotal * 0.6);
-    SetAmmoCapacity("Cell", (75 + Player.CapacityTotal * 5) / 10 * 10);
-    Player.Stim.VialMax = Player.CapacityTotal * 2.5;
+
+    // Calculate Ammo Capacity
+    if (GetCVar("drpg_levelup_natural"))
+    {
+        SetAmmoCapacity("Clip", (int)(140 + Player.CapacityTotal * 5.0) / 10 * 10);
+        SetAmmoCapacity("Shell", (int)(27 + Player.CapacityTotal * 1.4) / 2 * 2);
+        SetAmmoCapacity("RocketAmmo", (int)(7 + Player.CapacityTotal * 0.4));
+        SetAmmoCapacity("Cell", (int)(92 + Player.CapacityTotal * 3.4) / 10 * 10);
+        Player.Stim.VialMax = (int)(8 + Player.CapacityTotal * 1.8) / 5 * 5;
+        Player.MedkitMax = (int)(16 + Player.CapacityTotal * 3.5) / 5 * 5;
+    }
+    else
+    {
+        SetAmmoCapacity("Clip", (int)(115 + Player.CapacityTotal * 7.5) / 10 * 10);
+        SetAmmoCapacity("Shell", (int)(20 + Player.CapacityTotal * 2));
+        SetAmmoCapacity("RocketAmmo", (int)(5 + Player.CapacityTotal * 0.6));
+        SetAmmoCapacity("Cell", (int)(75 + Player.CapacityTotal * 5) / 10 * 10);
+        Player.Stim.VialMax = (int)(Player.CapacityTotal * 2.5) / 5 * 5;
+        Player.MedkitMax = Player.CapacityTotal * 5;
+    }
+
     Player.SurvivalBonus = Player.AgilityTotal / 5;
-    Player.MedkitMax = Player.CapacityTotal * 5;
 
     // Compatibility Handling - DoomRL Arsenal
     if (CompatMode == COMPAT_DRLA)
@@ -556,7 +571,10 @@ void CheckStats()
 
         // Increasing Rocket Ammo capacity for Demolitionist
         if (PlayerClass(PlayerNumber()) == 4)
-            SetAmmoCapacity("RocketAmmo", 9 + Player.CapacityTotal * 1.2);
+            if (GetCVar("drpg_levelup_natural"))
+                SetAmmoCapacity("RocketAmmo", (int)(9 + Player.CapacityTotal * 1.2));
+            else
+                SetAmmoCapacity("RocketAmmo", (int)(13 + Player.CapacityTotal * 0.8));
     }
 
     // Determine current stat cap

--- a/DoomRPG/scripts/Utils.c
+++ b/DoomRPG/scripts/Utils.c
@@ -267,12 +267,12 @@ NamedScript DECORATE int CheckInventoryMax()
     int MaxItems;
 
     if (GetCVar("drpg_levelup_natural"))
-        MaxItems = 9 + Player.CapacityTotal / 6;
+        MaxItems = 5 + Player.CapacityTotal / 8;
     else
-        MaxItems = 7 + Player.CapacityTotal / 3;
+        MaxItems = 4 + Player.CapacityTotal / 5;
 
-    if (MaxItems > 50)
-        MaxItems = 50;
+    if (MaxItems > 25)
+        MaxItems = 25;
 
     return MaxItems;
 }
@@ -298,9 +298,15 @@ NamedScript DECORATE int CheckCapacity()
         if (CompatMode == COMPAT_DRLA)
         {
             // Calculate capacity usage per category in DRLA, excluding weapons and modpacks
+            int AddCapacityXP;
             int DRLAItems = CheckInventory("RLArmorInInventory") + CheckInventory("RLSkullLimit") + CheckInventory("RLPhaseDeviceLimit") + (IsTechnician ? CheckInventory("RLScavengerModLimit") : CheckInventory("RLModLimit"));
             int DRLAMaxItems = DRLA_ARMOR_MAX + DRLA_SKULL_MAX + DRLA_DEVICE_MAX + DRLA_MODPACKS_MAX;
-            Player.CapacityXP += (RoundInt)((DRLAItems + Player.InvItems) * Scale / (DRLAMaxItems + MaxItems) * 5.0);
+            AddCapacityXP = (RoundInt)((DRLAItems + Player.InvItems) * Scale / (DRLAMaxItems + MaxItems) * 5.0);
+
+            if (AddCapacityXP > 0)
+                Player.CapacityXP += AddCapacityXP;
+            else if (DRLAItems + Player.InvItems >= 3 && (Timer() % 35) == 0)
+                Player.CapacityXP += (DRLAItems + Player.InvItems) / 3;
         }
         else
             Player.CapacityXP += (RoundInt)(Player.InvItems * Scale / MaxItems * 5.0);

--- a/DoomRPG/scripts/inc/Defs.h
+++ b/DoomRPG/scripts/inc/Defs.h
@@ -668,6 +668,7 @@ typedef enum
 #define MAX_SKILLS              17
 #define MAX_LEVELS              16
 #define MAX_SUMMONS             10
+#define MAX_FAMILIARS           5
 #define MAX_SKILLKEYS           8
 
 typedef enum

--- a/DoomRPG/scripts/inc/Monsters.h
+++ b/DoomRPG/scripts/inc/Monsters.h
@@ -75,7 +75,8 @@ NamedScript void MonsterOrangeAuraCheck(bool);
 fixed MapTotalMonstersMod();
 fixed MapTotalBossesMod();
 
+// Compatibility/Extensions
+NamedScript DECORATE void FamiliarInit(int, int);
 NamedScript DECORATE int GetMonsterHealthMax();
 NamedScript DECORATE int GetMonsterLevel();
-
 #endif

--- a/DoomRPG/scripts/inc/Structs.h
+++ b/DoomRPG/scripts/inc/Structs.h
@@ -804,6 +804,10 @@ struct PlayerData_S
     bool AutosaveTimerReset;
     bool SeenEventTip[MAPEVENT_MAX];
 
+    // Familiars
+    bool Familiars;
+    int FamiliarTID[MAX_FAMILIARS];
+
     // Nomad
     str NomadBasicItems[30];
     str NomadModPacks[30];


### PR DESCRIPTION
- DRLA Extended compat: now can banish Familiars with the Unsummon skill (use overdrive for this). For those who do not know how to use overdrive: Press the run button + the button to use the skill;
- fix "Legendoom Lite health pickups not working" #355;
- now to disassemble the item you have to pay some credits (for the balance);
- changed the formula for calculating ammo capacity when "Natural Stats Leveling" is enabled. Now the player with this setting will not have double ammo capacity advantage;
- changed the formula for gaining experience for capacity when "Natural Stats Leveling" is enabled. Now experience is gained if a character carries three or more items;
- reduced inventory capacity for use items. 6 at start, and 5 for every level of Capacity (or for every 8 if "Natural Stats Leveling" enabled).