### PR TITLE
Balance changes

### DIFF
--- a/DoomRPG/GAMEINFO.txt
+++ b/DoomRPG/GAMEINFO.txt
@@ -1,3 +1,3 @@
-startuptitle = "Doom RPG SE Rebalance (2023-03-07)"
+startuptitle = "Doom RPG SE Rebalance (2023-03-08)"
 startupcolors = "0092FF", "000000"
 startuptype = "Hexen"

--- a/DoomRPG/actors/Powerups.txt
+++ b/DoomRPG/actors/Powerups.txt
@@ -191,12 +191,12 @@ actor DRPGTimeFreezer : PowerupGiver
     
     Powerup.Type "TimeFreezer"
     Powerup.Color Black
-    Powerup.Duration -10
+    Powerup.Duration -15
 }
 
 actor DRPGTimeSphere : CustomInventory
 {
-    Tag "Time sphere (stops time for 10 seconds)"
+    Tag "Time sphere (stops time for 15 seconds)"
     
     Scale 0.75  
     
@@ -232,7 +232,7 @@ actor DRPGTimeSphere : CustomInventory
 // Regeneration Sphere
 actor DRPGRegenSphere : CustomInventory
 {
-    Tag "Regeneration sphere (regenerates health and energy rapidly for 30 seconds)"
+    Tag "Regeneration sphere (regenerates health and energy rapidly)"
     
     Inventory.DefMaxAmount
     Inventory.InterHubAmount 1000

--- a/DoomRPG/actors/Randomizers.txt
+++ b/DoomRPG/actors/Randomizers.txt
@@ -502,6 +502,7 @@ actor DRPGSoulSphereRandomizer : RandomSpawner Replaces Soulsphere
 {
     DropItem "DRPGSoulsphere"   255 70
     DropItem "DRPGSoulsphere2"  255 20
+    DropItem "DRPGRegenSphere"  255 20
     DropItem "DRPGSoulsphere3"  255 9
     DropItem "DRPGLifeDropper"  255 1
 }
@@ -552,6 +553,7 @@ actor DRPGInvulnerabilitySphereRandomizer : RandomSpawner Replaces Invulnerabili
 actor DRPGBlurSphereRandomizer : RandomSpawner Replaces BlurSphere
 {
     DropItem "DRPGBlurSphere"               255 100
+    DropItem "DRPGTimeSphere"               255 1
 //  DropItem "DRPGCrate"                    255 1
 }
 

--- a/DoomRPG/scripts/ItemData.c
+++ b/DoomRPG/scripts/ItemData.c
@@ -151,8 +151,8 @@ NamedScript void BuildItemData()
     // Powerups
     ITEMDATA_CATEGORY(4, "\CqPowerups", CF_NONE);
     ITEMDATA_DEF("DRPGInvulnerabilityCharge",    "Invulnerability Charge",              5000, 2, 5, "CRG2A0",  6, 22);
-    ITEMDATA_DEF("DRPGInvisibilityCharge",       "Invisibility Charge",                 2500, 1, 1, "CRG1A0",  6, 22);
-    ITEMDATA_DEF("DRPGTimeSphere",               "Time Sphere",                         1000, 4, 1, "TIMEA0", 16, 45);
+    ITEMDATA_DEF("DRPGInvisibilityCharge",       "Invisibility Charge",                 2000, 1, 1, "CRG1A0",  6, 22);
+    ITEMDATA_DEF("DRPGTimeSphere",               "Time Sphere",                         2500, 4, 1, "TIMEA0", 16, 45);
     ITEMDATA_DEF("DRPGRegenSphere",              "Regeneration Sphere",                 1000, 2, 1, "REGNA0", 12, 38);
     ITEMDATA_DEF("DRPGRadSuit",                  "Radiation Suit",                       250, 0, 0, "SUITA0", 11, 51);
     ITEMDATA_DEF("DRPGInfrared",                 "IR Goggles",                           500, 0, 0, "PVISA0", 11,  9);
@@ -881,16 +881,16 @@ NamedScript void BuildItemData()
         // Powerups
         ITEMDATA_CATEGORY(4, "\CqPowerups", CF_NONE);
 
-        ITEMDATA_DEF("InvulnerabilityCharge2",       "Invulnerability Charge",              5000,  2,  7, "CRG2A0",  6, 22);
-        ITEMDATA_DEF("InvisibilityCharge2",          "Invisibility Charge",                 2500,  1,  2, "CRG1A0",  6, 22);
-        ITEMDATA_DEF("DRPGTimeSphere",               "Time Sphere",                         1000,  4,  1, "TIMEA0", 16, 45);
+        ITEMDATA_DEF("InvulnerabilityCharge2",       "Invulnerability Charge",              5000,  3,  7, "CRG2A0",  6, 22);
+        ITEMDATA_DEF("InvisibilityCharge2",          "Invisibility Charge",                 2000,  1,  2, "CRG1A0",  6, 22);
+        ITEMDATA_DEF("DRPGTimeSphere",               "Time Sphere",                         2500,  4,  1, "TIMEA0", 16, 45);
         ITEMDATA_DEF("DRPGRegenSphere",              "Regeneration Sphere",                 1000,  2,  1, "REGNA0", 12, 38);
         ITEMDATA_DEF("RadSuit2",                     "Radiation Suit",                       250,  0,  0, "SUITA0", 11, 51);
         ITEMDATA_DEF("Infrared2",                    "IR Goggles",                           500,  0,  0, "PVISA0", 11,  9);
         ITEMDATA_DEF("Berserk2",                     "Berserk Pack",                        5000,  6, -1, "PSTRA0", 12, 15);
         ITEMDATA_DEF("RLAllmap2",                    "Computer Area Map",                  10000,  4,  3, "PMAPA0", 13, 23);
-        ITEMDATA_DEF("DRPGWings",                    "Wings",                               5000,  2,  5, "WINGA0", 13, 36);
-        ITEMDATA_DEF("Megasphere2",                  "Megasphere",                          5000,  4,  7, "MEGAA0", 12, 32);
+        ITEMDATA_DEF("DRPGWings",                    "Wings",                               5000,  5,  6, "WINGA0", 13, 36);
+        ITEMDATA_DEF("Megasphere2",                  "Megasphere",                          3000,  4,  4, "MEGAA0", 12, 32);
         ITEMDATA_DEF("DRPGImmunityCrystalMelee",     "Melee Immunity Crystal",             50000, -1,  8, "CRYSA0", 16, 48);
         ITEMDATA_DEF("DRPGImmunityCrystalBullet",    "\CcBullet\C- Immunity Crystal",      50000, -1,  8, "CRYSB0", 16, 48);
         ITEMDATA_DEF("DRPGImmunityCrystalFire",      "\CaFire\C- Immunity Crystal",        50000, -1,  8, "CRYSC0", 16, 48);

--- a/DoomRPG/scripts/Menu.c
+++ b/DoomRPG/scripts/Menu.c
@@ -703,7 +703,17 @@ void DrawStatsMenu()
         EndHudMessage(HUDMSG_PLAIN, 0, "Brick",              30.1,   136.0,  0.05);
         HudMessage("EP Timer: %.2k Sec", (fixed)(Player.EPTime / 35.0K));
         EndHudMessage(HUDMSG_PLAIN, 0, "LightBlue",          30.1,   144.0,  0.05);
-        HudMessage("Regen Sphere: %d Sec", (int)(15 + (Player.RegenerationTotal / 2)));
+        if (GetCVar("drpg_levelup_natural"))
+        {
+            HudMessage("Regen Sphere: %d Sec", (int)(40 + Player.RegenerationTotal));
+            EndHudMessage(HUDMSG_PLAIN, 0, "Purple",             30.1,   152.0,  0.05);
+        }
+        else
+        {
+            HudMessage("Regen Sphere: %d Sec", (int)(40 + Player.RegenerationTotal * 2));
+            EndHudMessage(HUDMSG_PLAIN, 0, "Purple",             30.1,   152.0,  0.05);
+        }
+        HudMessage("Regen Sphere: %d Sec", (int)(40 + Player.RegenerationTotal * 2));
         EndHudMessage(HUDMSG_PLAIN, 0, "Purple",             30.1,   152.0,  0.05);
         HudMessage("Toxicity Regen: %d Sec", 30 - Player.ToxicityRegenBonus);
         EndHudMessage(HUDMSG_PLAIN, 0, "Green",              30.1,   160.0,  0.05);

--- a/DoomRPG/scripts/Stats.c
+++ b/DoomRPG/scripts/Stats.c
@@ -833,8 +833,18 @@ void DoRegen()
         int Angle = GetActorAngle(0) * 256;
         SpawnForced("DRPGRegenSphereEffect", X, Y, Z + 32.0, AuraTID, Angle);
 
-        Player.HPRate += 1.0 + (fixed)Player.RegenerationTotal / (2.0 + (fixed)Player.RegenerationTotal / 30.0);
-        Player.EPRate += 1.0 + (fixed)Player.RegenerationTotal / (2.0 + (fixed)Player.RegenerationTotal / 30.0);
+        int HPTimeMod = (1.0 / Player.HPAmount) * 25.0;
+        if (HPTimeMod < 2.0) HPTimeMod = 2.0;
+
+        int EPTimeMod = (1.0 / Player.EPAmount) * 25.0;
+        if (EPTimeMod < 2.0) EPTimeMod = 2.0;
+
+        if (Timer() % (int)(Player.HPTime / HPTimeMod) == 0)
+            Player.HPRate += (fixed)(Player.HPTime - Player.HPRate);
+
+        if (Timer() % (int)(Player.EPTime / EPTimeMod) == 0)
+            Player.EPRate += (fixed)(Player.EPTime - Player.EPRate);
+
         Player.RegenBoostTimer--;
 
         // Pass Radius and Height to the Auras for DECORATE usage

--- a/DoomRPG/scripts/Utils.c
+++ b/DoomRPG/scripts/Utils.c
@@ -896,7 +896,19 @@ NamedScript DECORATE void CorpsesCleanup()
 // Used by the RegenSphere to temporarily increase regen rates
 NamedScript DECORATE void RegenBoost()
 {
-    Player.RegenBoostTimer += (35 * 15) + ((Player.RegenerationTotal / 2) * 35);
+    int AddBoostTimer;
+
+    if (GetCVar("drpg_levelup_natural"))
+        AddBoostTimer = (int)(40 + Player.RegenerationTotal);
+    else
+        AddBoostTimer = (int)(40 + Player.RegenerationTotal * 2);
+
+    if (AddBoostTimer > 180) AddBoostTimer = 180;
+
+    Player.RegenBoostTimer += AddBoostTimer * 35;
+
+    if (Player.RegenBoostTimer > 35 * 60 * GetCVar("drpg_skill_auratimercap"))
+        Player.RegenBoostTimer = 35 * 60 * GetCVar("drpg_skill_auratimercap");
 }
 
 // Set Skill Level during the game


### PR DESCRIPTION
- the Regeneration Sphere formula has been changed. Now this sphere is more useful in the early stages of the game, and is not imbalanced in the later stage;
- Time Freeze Sphere now works for 15 seconds (instead of 10). The cost of the sphere in the store is equivalent to the cost of Vial Chrono;
- now regeneration and freezing time spheres can appear on maps instead of other spheres (not much chance of a drop).