### PR TITLE
Update 1.31g

### DIFF
--- a/DoomRPG-RLArsenal-Extended/zscript/DRLAX/Items.zscript
+++ b/DoomRPG-RLArsenal-Extended/zscript/DRLAX/Items.zscript
@@ -690,7 +690,7 @@ class DRLAX_TrappedMegaSphere : DRLAX_TrappedSoulBase
 
 	override void Init()
 	{
-		powerupitem = "RLMegaSphere";
+		powerupitem = "Megasphere2";
 	}
 }
 

--- a/DoomRPG-RLArsenal/actors/doomrl/Powerups.txt
+++ b/DoomRPG-RLArsenal/actors/doomrl/Powerups.txt
@@ -309,7 +309,7 @@ actor MegasphereSpotSpawner2 : RLMegasphereSpotSpawner replaces MegaSphere
     Spawn:
         TNT1 A 0 A_JumpIf(CallACS("DRPGCheckTiem"), 2)
         TNT1 A 0 A_JumpIf(CallACS("DRLA_specialstarts") == 2, "SpawnDuke2")
-        TNT1 A 0 A_SpawnItemEx ("RLMegasphere", 0, 0, 0, 0, 0, 0, 0, SXF_NOCHECKPOSITION)
+        TNT1 A 0 A_SpawnItemEx ("Megasphere2", 0, 0, 0, 0, 0, 0, 0, SXF_NOCHECKPOSITION)
         TNT1 A 0 A_SpawnItemEx ("RLRandomSkullSpawner", random(-24,24),random(-24,24),0, 0,0,0, 0, SXF_NOCHECKPOSITION, 12)
         TNT1 A 0 A_SpawnItemEx ("RLMegasphereSpot", 0, 0, 0, 0, 0, 0, 0, SXF_NOCHECKPOSITION)
         Stop
@@ -321,7 +321,22 @@ actor Megasphere2 : DRPGMegasphere
 	States
 	{
 	Pickup:
+		TNT1 A 0 A_TakeInventory("PowerRL1800Cooldown",1)
+		TNT1 A 0 A_TakeInventory("PowerRL600Cooldown",1)
+		TNT1 A 0 A_TakeInventory("PowerRL300Cooldown",1)
+		TNT1 A 0 A_TakeInventory("PowerRL180Cooldown",1)
+		TNT1 A 0 A_TakeInventory("PowerRL120KateCooldown",1)
+		TNT1 A 0 A_TakeInventory("PowerRL120Cooldown",1)
+		TNT1 A 0 A_TakeInventory("PowerRL90Cooldown",1)
+		TNT1 A 0 A_TakeInventory("PowerRL60Cooldown",1)
+		TNT1 A 0 A_TakeInventory("PowerRL45Cooldown",1)
+		TNT1 A 0 A_TakeInventory("PowerRL30Cooldown",1)
+		TNT1 A 0 A_TakeInventory("PowerRL20Cooldown",1)
+		TNT1 A 0 A_TakeInventory("PowerRL15Cooldown",1)
+		TNT1 A 0 A_TakeInventory("PowerRL10Cooldown",1)
+		TNT1 A 0 A_TakeInventory("PowerRL5Cooldown",1)
 		TNT1 A 0 A_GiveInventory("RLSoulSphere4")
+		TNT1 A 0 A_GiveInventory("RLStamina", 100)
 		TNT1 A 0 ACS_NamedExecuteAlways("AddEP", 0, 1000000)
 		TNT1 A 0 ACS_NamedExecuteAlways("AddShield", 0, 1000000)
         TNT1 A 0 ACS_NamedExecuteAlways("AddMedkit", 0, 1000000)
@@ -338,15 +353,15 @@ actor Megasphere2 : DRPGMegasphere
         stop
 	100Armor:
 		TNT1 A 0 A_GiveInventory("RLArmorBonus100Megasphere", 1)
-    TNT1 A 0 A_JumpIfInventory ("RLDemonicSetBonusActive", 1, "DemonicCharge")
+		TNT1 A 0 A_JumpIfInventory ("RLDemonicSetBonusActive", 1, "DemonicCharge")
 		Stop
 	150Armor:
 		TNT1 A 0 A_GiveInventory("RLArmorBonus150Megasphere", 1)
-    TNT1 A 0 A_JumpIfInventory ("RLDemonicSetBonusActive", 1, "DemonicCharge")
+		TNT1 A 0 A_JumpIfInventory ("RLDemonicSetBonusActive", 1, "DemonicCharge")
 		Stop
 	200Armor:
 		TNT1 A 0 A_GiveInventory("RLArmorBonus200Megasphere", 1)
-    TNT1 A 0 A_JumpIfInventory ("RLDemonicSetBonusActive", 1, "DemonicCharge")
+		TNT1 A 0 A_JumpIfInventory ("RLDemonicSetBonusActive", 1, "DemonicCharge")
 		Stop
     DemonicCharge:
         TNT1 A 0 A_GiveInventory ("RLDemonicCarapaceSupercharge", 1)

--- a/DoomRPG/GAMEINFO.txt
+++ b/DoomRPG/GAMEINFO.txt
@@ -1,3 +1,3 @@
-startuptitle = "Doom RPG SE Rebalance (2023-03-13)"
+startuptitle = "Doom RPG SE Rebalance (2023-03-14)"
 startupcolors = "0092FF", "000000"
 startuptype = "Hexen"

--- a/DoomRPG/actors/Randomizers.txt
+++ b/DoomRPG/actors/Randomizers.txt
@@ -502,7 +502,7 @@ actor DRPGSoulSphereRandomizer : RandomSpawner Replaces Soulsphere
 {
     DropItem "DRPGSoulsphere"   255 70
     DropItem "DRPGSoulsphere2"  255 20
-    DropItem "DRPGRegenSphere"  255 15
+    DropItem "DRPGRegenSphere"  255 10
     DropItem "DRPGSoulsphere3"  255 9
     DropItem "DRPGLifeDropper"  255 1
 }

--- a/DoomRPG/scripts/HUD.c
+++ b/DoomRPG/scripts/HUD.c
@@ -2332,8 +2332,8 @@ Start:
             {
                 if (CheckWeapon("RLAntiFreakJackal") && CheckInventory("RLAntiFreakJackalDemonArtifacts")) // Jackal/Casull
                 {
-                    JackelItem = &ItemData[0][42]; // Should probably come up with a better way to reference these?
-                    CasullItem = &ItemData[0][43];
+                    JackelItem = &ItemData[0][54]; // Should probably come up with a better way to reference these?
+                    CasullItem = &ItemData[0][42];
 
                     PrintSprite(JackelItem->Sprite.Name, 0, X + JackelItem->Sprite.XOff, Y + JackelItem->Sprite.YOff + (int)(Sin((fixed)Timer() / 128.0) * 4.0), 0.05);
                     PrintSprite(CasullItem->Sprite.Name, 0, X + CasullItem->Sprite.XOff + 32.0, Y + CasullItem->Sprite.YOff + (int)(Cos((fixed)Timer() / 128.0) * 4.0), 0.05);

--- a/DoomRPG/scripts/ItemData.c
+++ b/DoomRPG/scripts/ItemData.c
@@ -430,60 +430,60 @@ NamedScript void BuildItemData()
 
         // Exotic Weapons
         ITEMDATA_DEF("RLBlaster",                               "Blaster \Ct[Exotic]\C-",                                 2000,  2, 1, "BLASX0", 12, 14);
-        ITEMDATA_DEF("RLCombatPistol",                          "Combat Pistol \Ct[Exotic]\C-",                           3000,  3, 2, "OLOKX0", 10, 13);
-        ITEMDATA_DEF("RLHandCannon",                            "Handcannon \Ct[Exotic]\C-",                              4000,  4, 3, "DEAPX0", 11, 14);
-        ITEMDATA_DEF("RLMarksmanPistol",                        "Marksman Pistol \Ct[Exotic]\C-",                        10000,  5, 4, "MRKPX0",  9, 12);
+        ITEMDATA_DEF("RLCombatPistol",                          "Combat Pistol \Ct[Exotic]\C-",                           3000,  3, 1, "OLOKX0", 10, 13);
+        ITEMDATA_DEF("RLHandCannon",                            "Handcannon \Ct[Exotic]\C-",                              4000,  4, 2, "DEAPX0", 11, 14);
+        ITEMDATA_DEF("RLMarksmanPistol",                        "Marksman Pistol \Ct[Exotic]\C-",                        10000,  5, 3, "MRKPX0",  9, 12);
         ITEMDATA_DEF("RLUzi",                                   "Uzi \Ct[Exotic]\C-",                                     6000,  4, 2, "RUZIX0", 20, 26);
         ITEMDATA_DEF("RLAssaultShotgun",                        "Assault Shotgun \Ct[Exotic]\C-",                        24000,  5, 3, "ASHOX0", 31, 27);
         ITEMDATA_DEF("RLPlasmaShotgun",                         "Plasma Shotgun \Ct[Exotic]\C-",                         30000,  6, 4, "PSHOX0", 22, 14);
         ITEMDATA_DEF("RLCombatTranslocator",                    "Combat Translocator \Ct[Exotic]\C-",                    20000,  6, 4, "CTLOX0", 18, 11);
         ITEMDATA_DEF("RLMissileLauncher",                       "Missile Launcher \Ct[Exotic]\C-",                       32000,  7, 5, "CLAUX0", 45, 24);
         ITEMDATA_DEF("RLNapalmLauncher",                        "Napalm Launcher \Ct[Exotic]\C-",                        48000,  8, 6, "NAPAX0", 22, 20);
-        ITEMDATA_DEF("RLMinigun",                               "Minigun \Ct[Exotic]\C-",                                62000, 10, 7, "ZGGGX0", 30, 20);
-        ITEMDATA_DEF("RLSuperShotgun",                          "Super Shotgun \Ct[Exotic]\C-",                          64000, 10, 7, "NSSGX0", 27,  9);
-        ITEMDATA_DEF("RLLaserRifle",                            "Laser Rifle \Ct[Exotic]\C-",                            66000, 11, 7, "LASRX0", 18, 11);
-        ITEMDATA_DEF("RLTristarBlaster",                        "Tristar Blaster \Ct[Exotic]\C-",                        68000, 11, 7, "TRISX0", 35, 35);
+        ITEMDATA_DEF("RLTristarBlaster",                        "Tristar Blaster \Ct[Exotic]\C-",                        50000,  8, 6, "TRISX0", 35, 35);
+        ITEMDATA_DEF("RLMinigun",                               "Minigun \Ct[Exotic]\C-",                                60000, 10, 7, "ZGGGX0", 30, 20);
+        ITEMDATA_DEF("RLSuperShotgun",                          "Super Shotgun \Ct[Exotic]\C-",                          65000, 10, 7, "NSSGX0", 27,  9);
+        ITEMDATA_DEF("RLLaserRifle",                            "Laser Rifle \Ct[Exotic]\C-",                            67500, 11, 7, "LASRX0", 18, 11);
         ITEMDATA_DEF("RLNuclearPlasmaPistol",                   "Nuclear Plasma Pistol \Ct[Exotic]\C-",                  90000, 12, 8, "NUPPX0", 11, 14);
         ITEMDATA_DEF("RLNuclearPlasmaRifle",                    "Nuclear Plasma Rifle \Ct[Exotic]\C-",                  120000, 12, 9, "NUKPX0", 23, 14);
         ITEMDATA_DEF("RLNuclearBFG9000",                        "Nuclear BFG9000 \Ct[Exotic]\C-",                       200000, 12, 10, "NUKBX0", 28, 18);
 
         // Superior Weapons
-        ITEMDATA_DEF("RLMarksmanRifle",                         "Marksman Rifle \Ci[Superior]\C-",                       52000,  8, 6, "MRKRX0", 26, 18);
+        ITEMDATA_DEF("RLPP7",                                   "PP7 \Ci[Superior]\C-",                                  26000,  6, 4, "BPP7X0", 8,  10);
+        ITEMDATA_DEF("RLThompson",                              "Tommy Gun \Ci[Superior]\C-",                            30000,  7, 4, "TGUNX0", 23, 17);
+        ITEMDATA_DEF("RLMarksmanRifle",                         "Marksman Rifle \Ci[Superior]\C-",                       40000,  7, 5, "MRKRX0", 26, 18);
+        ITEMDATA_DEF("RLHuntingRevolver",                       "Hunting Revolver \Ci[Superior]\C-",                     50000,  8, 6, "HREVX0", 12, 14);
         ITEMDATA_DEF("RLVanguardRifle",                         "Vanguard Rifle \Ci[Superior]\C-",                       60000,  8, 6, "VANRX0", 26, 13);
-        ITEMDATA_DEF("RLHuntingRevolver",                       "Hunting Revolver \Ci[Superior]\C-",                     35000,  7, 6, "HREVX0", 12, 14);
-        ITEMDATA_DEF("RLThompson",                              "Tommy Gun \Ci[Superior]\C-",                            30000,  7, 5, "TGUNX0", 23, 17);
-        ITEMDATA_DEF("RLPP7",                                   "PP7 \Ci[Superior]\C-",                                  26000,  6, 5, "BPP7X0", 8,  10);
-        ITEMDATA_DEF("RLHuntingShotgun",                        "Hunting Shotgun \Ci[Superior]\C-",                      80000, 12, 8, "HUNTX0", 32, 12);
         ITEMDATA_DEF("RLRCP90",                                 "RC-P90 \Ci[Superior]\C-",                               76000, 11, 7, "RCP9X0", 24, 15);
+        ITEMDATA_DEF("RLHuntingShotgun",                        "Hunting Shotgun \Ci[Superior]\C-",                      80000, 12, 8, "HUNTX0", 32, 12);
 
         // Unique Weapons
+        ITEMDATA_DEF("RLGrammatonClericBeretta",                "Grammaton Cleric Beretta \Cd[Unique]\C-",               30000, -1, 4, "GCBPX0", 12, 13);
+        ITEMDATA_DEF("RLWidowmakerSMG",                         "Widowmaker SMG \Cd[Unique]\C-",                         32500, -1, 4, "WSMGX0", 24, 20);
+        ITEMDATA_DEF("RLRevenantsLauncher",                     "Revenant's Launcher \Cd[Unique]\C-",                    35000, -1, 4, "REVLX0", 22, 13);
+        ITEMDATA_DEF("RLPlasmaRedirectionCannon",               "Plasma Redirection Cannon \Cd[Unique]\C-",              37500, -1, 4, "PRDCX0", 32, 24);
         ITEMDATA_DEF("RLTrigun",                                "Trigun \Cd[Unique]\C-",                                 40000, -1, 5, "TRIGX0", 15, 12);
-        ITEMDATA_DEF("RLWidowmakerSMG",                         "Widowmaker SMG \Cd[Unique]\C-",                         34000, -1, 5, "WSMGX0", 24, 20);
-        ITEMDATA_DEF("RLFragShotgun",                           "Frag Shotgun \Cd[Unique]\C-",                           30000, -1, 5, "FRSHX0", 28, 11);
-        ITEMDATA_DEF("RLRailgun",                               "Railgun \Cd[Unique]\C-",                                38000, -1, 5, "RAILX0", 23, 13);
-        ITEMDATA_DEF("RLRevenantsLauncher",                     "Revenant's Launcher \Cd[Unique]\C-",                    40000, -1, 5, "REVLX0", 22, 13);
-        ITEMDATA_DEF("RLGrammatonClericBeretta",                "Grammaton Cleric Beretta \Cd[Unique]\C-",               50000, -1, 6, "GCBPX0", 12, 13);
-        ITEMDATA_DEF("RLJackhammer",                            "Jackhammer \Cd[Unique]\C-",                             55000, -1, 6, "JHAMX0", 27, 14);
+        ITEMDATA_DEF("RLChameleonRifle",                        "Chameleon Rifle \Cd[Unique]\C-",                        42500, -1, 5, "CRM1X0", 26, 18);
+        ITEMDATA_DEF("RLFragShotgun",                           "Frag Shotgun \Cd[Unique]\C-",                           45000, -1, 5, "FRSHX0", 28, 11);
+        ITEMDATA_DEF("RLRailgun",                               "Railgun \Cd[Unique]\C-",                                47500, -1, 5, "RAILX0", 23, 13);
+        ITEMDATA_DEF("RLHellsingARMSCasull",                    "Hellsing ARMS Casull \Cd[Unique]\C-",                   50000, -1, 6, "HSACX0", 15, 14);
+        ITEMDATA_DEF("RLMarathonAssaultRifle",                  "MA-75B Assault Rifle \Cd[Unique]\C-",                   52500, -1, 6, "MA75Y0",  0,  0);
+        ITEMDATA_DEF("RLMarathonShotguns",                      "WSTE-M5 Shotgun \Cd[Unique]\C-",                        55000, -1, 6, "WSTEY0",  6,  6);
+        ITEMDATA_DEF("RLJackhammer",                            "Jackhammer \Cd[Unique]\C-",                             57500, -1, 6, "JHAMX0", 27, 14);
         ITEMDATA_DEF("RLSteelBeast",                            "Steel Beast \Cd[Unique]\C-",                            60000, -1, 6, "STBEX0", 36, 11);
-        ITEMDATA_DEF("RLPlasmaRedirectionCannon",               "Plasma Redirection Cannon \Cd[Unique]\C-",              65000, -1, 6, "PRDCX0", 32, 24);
-        ITEMDATA_DEF("RLMysteriousMagnum",                      "Mysterious Magnum \Cd[Unique]\C-",                      70000, -1, 7, "MMAGX0", 15, 12);
-        ITEMDATA_DEF("RLNullPointer",                           "Charch's Null Pointer \Cd[Unique]\C-",                  72000, -1, 7, "NULPX0", 23, 14);
-        ITEMDATA_DEF("RLSussGun",                               "Suss Gun \Cd[Unique]\C-",                               74000, -1, 7, "SUSSX0", 38, 37);
-        ITEMDATA_DEF("RLMarathonAssaultRifle",                  "MA-75B Assault Rifle \Cd[Unique]\C-",                   76000, -1, 7, "MA75Y0",  0,  0);
-        ITEMDATA_DEF("RLMarathonShotguns",                      "WSTE-M5 Shotgun \Cd[Unique]\C-",                        76000, -1, 7, "WSTEY0",  6,  6);
-        ITEMDATA_DEF("RLAntiFreakJackal",                       "Anti-Freak Jackal \Cd[Unique]\C-",                      76000, -1, 7, "AFJKX0", 15, 14);
-        ITEMDATA_DEF("RLHellsingARMSCasull",                    "Hellsing ARMS Casull \Cd[Unique]\C-",                   78000, -1, 7, "HSACX0", 15, 14);
-        ITEMDATA_DEF("RLUnknownHerald",                         "Unknown Herald \Cd[Unique]\C-",                         78000, -1, 7, "UNKHX0",  8, 10);
-        ITEMDATA_DEF("RLTantrumCannon",                         "Quantum Tantrum Cannon \Cd[Unique]\C-",                 80000, -1, 7, "QTCWX0", 14, 13);
-        ITEMDATA_DEF("RLParticleBeamCannon",                    "Particle Beam Cannon \Cd[Unique]\C-",                   84000, -1, 8, "PBCNX0", 26, 16);
-        ITEMDATA_DEF("RLMIRVLauncher",                          "MIRV Launcher \Cd[Unique]\C-",                          86000, -1, 8, "MIRVX0", 20, 16);
+        ITEMDATA_DEF("RLTantrumCannon",                         "Quantum Tantrum Cannon \Cd[Unique]\C-",                 62500, -1, 6, "QTCWX0", 14, 13);
+        ITEMDATA_DEF("RLMysteriousMagnum",                      "Mysterious Magnum \Cd[Unique]\C-",                      65000, -1, 7, "MMAGX0", 15, 12);
+        ITEMDATA_DEF("RLUnknownHerald",                         "Unknown Herald \Cd[Unique]\C-",                         67500, -1, 7, "UNKHX0",  8, 10);
+        ITEMDATA_DEF("RLNanomachicArmamentGenerator",           "Nanomachic Armament Generator \Cd[Unique]\C-",          70000, -1, 7, "NAG0X0", 13, 19);
+        ITEMDATA_DEF("RLSussGun",                               "Suss Gun \Cd[Unique]\C-",                               72500, -1, 7, "SUSSX0", 38, 37);
+        ITEMDATA_DEF("RLNullPointer",                           "Charch's Null Pointer \Cd[Unique]\C-",                  75000, -1, 7, "NULPX0", 23, 14);
+        ITEMDATA_DEF("RLMIRVLauncher",                          "MIRV Launcher \Cd[Unique]\C-",                          77500, -1, 7, "MIRVX0", 20, 16);
+        ITEMDATA_DEF("RLAntiFreakJackal",                       "Anti-Freak Jackal \Cd[Unique]\C-",                      80000, -1, 8, "AFJKX0", 15, 14);
+        ITEMDATA_DEF("RLParticleBeamCannon",                    "Particle Beam Cannon \Cd[Unique]\C-",                   85000, -1, 8, "PBCNX0", 26, 16);
         ITEMDATA_DEF("RLBFG10k",                                "BFG10k \Cd[Unique]\C-",                                 90000, -1, 8, "BFG4X0", 34, 24);
-        ITEMDATA_DEF("RLChameleonRifle",                        "Chameleon Rifle \Cd[Unique]\C-",                       100000, -1, 8, "CRM1X0", 26, 18);
-        ITEMDATA_DEF("RLQuadShotgun",                           "Quad Shotgun \Cd[Unique]\C-",                          125000, -1, 8, "SHT4X0", 26, 16);
-        ITEMDATA_DEF("RLNanomachicArmamentGenerator",           "Nanomachic Armament Generator \Cd[Unique]\C-",         150000, -1, 8, "NAG0X0", 13, 19);
-        ITEMDATA_DEF("RLLightweaver",                           "Lightweaver \Cd[Unique]\C-",                           175000, -1, 8, "KARAX0", 16, 10);
-        ITEMDATA_DEF("RLLuciferCannon",                         "Lucifer Cannon \Cd[Unique]\C-",                        225000, -1, 8, "LCFGX0", 30, 26);
-        ITEMDATA_DEF("RLDirectHit",                             "Direct Hit \Cd[Unique]\C-",                            275000, -1, 8, "DHTGX0", 20, 20);
+        ITEMDATA_DEF("RLQuadShotgun",                           "Quad Shotgun \Cd[Unique]\C-",                          100000, -1, 8, "SHT4X0", 26, 16);
+        ITEMDATA_DEF("RLLightweaver",                           "Lightweaver \Cd[Unique]\C-",                           150000, -1, 8, "KARAX0", 16, 10);
+        ITEMDATA_DEF("RLLuciferCannon",                         "Lucifer Cannon \Cd[Unique]\C-",                        200000, -1, 8, "LCFGX0", 30, 26);
+        ITEMDATA_DEF("RLDirectHit",                             "Direct Hit \Cd[Unique]\C-",                            250000, -1, 8, "DHTGX0", 20, 20);
         ITEMDATA_DEF("RLNuclearOnslaught",                      "Nuclear Onslaught \Cd[Unique]\C-",                     300000, -1, 9, "NKO0X0", 29, 54);
         ITEMDATA_DEF("RLTriadCannon",                           "Triad Cannon \Cd[Unique]\C-",                          350000, -1, 9, "TRIDX0", 25, 26);
         // ITEMDATA_DEF("RLSubtleKnife",                           "Subtle Knife \Cd[Unique]\C-",                           30000, -1, "SUBKX0", 38, 37);
@@ -492,8 +492,8 @@ NamedScript void BuildItemData()
 
         // Demonic Weapons
         // ITEMDATA_DEF("RLMonsterFrisbee",                        "Monster Frisbee \Cg[Demonic]\C-",                       78000, -1, "MFRSX0", 37, 21);
-        ITEMDATA_DEF("RLDeathsGaze",                            "Death's Gaze \Cg[Demonic]\C-",                          80000, -1, 7, "DGAZX0", 10, 13);
-        ITEMDATA_DEF("RLSoulstormRifle",                        "Soulstorm Rifle \Cg[Demonic]\C-",                      120000, -1, 8, "SOLDX0", 27, 17);
+        ITEMDATA_DEF("RLDeathsGaze",                            "Death's Gaze \Cg[Demonic]\C-",                          80000, -1, 6, "DGAZX0", 10, 13);
+        ITEMDATA_DEF("RLSoulstormRifle",                        "Soulstorm Rifle \Cg[Demonic]\C-",                      120000, -1, 7, "SOLDX0", 27, 17);
         ITEMDATA_DEF("RLHellsReign",                            "Hell's Reign \Cg[Demonic]\C-",                         200000, -1, 8, "HELRX0", 37, 21);
         // ITEMDATA_DEF("RLMortalyzer",                            "Mortalyzer \Cg[Demonic]\C-",                            58000, -1, "MRTZX0", 37, 21);
         // ITEMDATA_DEF("RLDreadshotMortar",                       "Dreadshot Mortar \Cg[Demonic]\C-",                      60000, -1, "DSMTX0", 37, 21);
@@ -856,11 +856,11 @@ NamedScript void BuildItemData()
         ITEMDATA_DEF("RLNanoAblativeArmorPickup",                       "Nano Ablative Armor \Cd[Unique]\C-",                40000, -1, 6, "NABLA0", 16, 19);
         ITEMDATA_DEF("RLShieldedArmorPickup",                           "Shielded Armor \Cd[Unique]\C-",                     40000, -1, 7, "SSHDA0", 16, 25);
         ITEMDATA_DEF("RLTerminusEst13BattlesuitArmorPickup",            "Terminus Battlesuit \Cd[Unique]\C-",                41000, -1, 7, "TEBSA0", 17, 30);
-        ITEMDATA_DEF("RLKateMatterstormHarnessArmorPickup",             "K-8 Matterstorm Harness \Cd[Unique]\C-",            41000, -1, 7, "K8MHA0", 16, 18);
-        ITEMDATA_DEF("RLJetpackArmorPickup",                            "Jetpack \Cd[Unique]\C-",                            42000, -1, 7, "JETPA0", 14, 36);
+        ITEMDATA_DEF("RLZeroDiamondAssaultforceArmorPickup",            "0D-1a Assaultforce Armor \Cd[Unique]\C-",           42000, -1, 7, "0DAFA0", 15, 32);
+        ITEMDATA_DEF("RLKateMatterstormHarnessArmorPickup",             "K-8 Matterstorm Harness \Cd[Unique]\C-",            42500, -1, 7, "K8MHA0", 16, 18);
+        ITEMDATA_DEF("RLJetpackArmorPickup",                            "Jetpack \Cd[Unique]\C-",                            43000, -1, 7, "JETPA0", 14, 36);
         ITEMDATA_DEF("RLSoloOperativeSuitArmorPickup",                  "Solo Operative Suit \Cd[Unique]\C-",                44444, -1, 7, "SSOSA0", 11, 35);
         ITEMDATA_DEF("RLPrototypeAssaultShieldArmorPickup",             "Prototype Assault Shield \Cd[Unique]\C-",           45000, -1, 8, "PASSA0", 12, 18);
-        ITEMDATA_DEF("RLZeroDiamondAssaultforceArmorPickup",            "0D-1a Assaultforce Armor \Cd[Unique]\C-",           47000, -1, 8, "0DAFA0", 15, 32);
         ITEMDATA_DEF("RLMaleksArmorPickup",                             "Malek's Armor \Cd[Unique]\C-",                      50000, -1, 8, "MALKA0", 15, 31);
         ITEMDATA_DEF("RLKyleTeslaboltArmorPickup",                      "K1-L3 Teslabolt Armor \Cd[Unique]\C-",              56000, -1, 8, "KTESA0", 17, 30);
         ITEMDATA_DEF("RLTorgueBlastplateArmorPickup",                   "Torgue Blastplate Armor \Cd[Unique]\C-",            60000, -1, 8, "TORAA0", 17, 21);
@@ -1434,7 +1434,7 @@ NamedScript DECORATE void DRPGWeaponSpawner(int Weapon)
 
                 if (!ItemSpawned && ItemData[ItemCategory][j].Rarity >= RarityMin && ItemData[ItemCategory][j].Rarity <= RarityMax)
                 {
-                    if (Random(0, (100 + (25 * Amount)) * (1 + ItemData[ItemCategory][j].Dropped * 4)) <= 50)
+                    if (Random(0, (100 + (25 * Amount)) * (1 + ItemData[ItemCategory][j].Spawned * 4)) <= 50)
                     {
                         // Set weapon index
                         Index = j;
@@ -1465,42 +1465,51 @@ NamedScript DECORATE void DRPGWeaponSpawner(int Weapon)
         // Set chances for Exotic/Superior/Unique/Demonic/Legendary weapons
         if (CompatMode == COMPAT_DRLA && ItemSpawned)
         {
+            if (StrMid(ItemData[ItemCategory][Index].Name, StrLen(ItemData[ItemCategory][Index].Name) - 9, 6) == "Common")
+            {
+                ActorToSpawn = StrParam("%SPickup", ActorToSpawn);
+            }
             if (StrMid(ItemData[ItemCategory][Index].Name, StrLen(ItemData[ItemCategory][Index].Name) - 9, 6) == "Exotic")
             {
+                ActorToSpawn = StrParam("%SPickup", ActorToSpawn);
                 Players(0).WeaponExoticChance = 0;
-                ItemData[ItemCategory][Index].Dropped++;
+                ItemData[ItemCategory][Index].Spawned++;
             }
             else
                 Players(0).WeaponExoticChance += 15.0 * (fixed)Modifier / 15.0;
 
             if (StrMid(ItemData[ItemCategory][Index].Name, StrLen(ItemData[ItemCategory][Index].Name) - 11, 8) == "Superior")
             {
+                ActorToSpawn = StrParam("%SPickup", ActorToSpawn);
                 Players(0).WeaponSuperiorChance = 0;
-                ItemData[ItemCategory][Index].Dropped++;
+                ItemData[ItemCategory][Index].Spawned++;
             }
             else
                 Players(0).WeaponSuperiorChance += 0.5 * (fixed)Modifier / 15.0;
 
             if (StrMid(ItemData[ItemCategory][Index].Name, StrLen(ItemData[ItemCategory][Index].Name) - 9, 6) == "Unique")
             {
+                ActorToSpawn = StrParam("%SWorldSpawnPickup", ActorToSpawn);
                 Players(0).WeaponUniqueChance = 0;
-                ItemData[ItemCategory][Index].Dropped++;;
+                ItemData[ItemCategory][Index].Spawned++;;
             }
             else
                 Players(0).WeaponUniqueChance += 2.5 * (fixed)Modifier / 15.0;
 
             if (StrMid(ItemData[ItemCategory][Index].Name, StrLen(ItemData[ItemCategory][Index].Name) - 10, 7) == "Demonic")
             {
+                ActorToSpawn = StrParam("%SWorldSpawnPickup", ActorToSpawn);
                 Players(0).WeaponDemonicChance = 0;
-                ItemData[ItemCategory][Index].Dropped++;;
+                ItemData[ItemCategory][Index].Spawned++;;
             }
             else
                 Players(0).WeaponDemonicChance += 0.3 * (fixed)Modifier / 15.0;
 
             if (StrMid(ItemData[ItemCategory][Index].Name, StrLen(ItemData[ItemCategory][Index].Name) - 12, 9) == "Legendary")
             {
+                ActorToSpawn = StrParam("%SWorldSpawnPickup", ActorToSpawn);
                 Players(0).WeaponLegendaryChance = 0;
-                ItemData[ItemCategory][Index].Dropped++;;
+                ItemData[ItemCategory][Index].Spawned++;;
             }
             else
                 Players(0).WeaponLegendaryChance += 0.2 * (fixed)Modifier / 15.0;
@@ -1533,31 +1542,62 @@ NamedScript DECORATE void DRPGWeaponUniqueSpawner()
     str ActorToSpawn;
     bool ItemSpawned;
     int ItemCategory = 0;
-    int RarityMin = 5;
-    int RarityMax = 5 + RoundInt(5.0 * MapLevelModifier);
+    int RarityMin;
+    int RarityMax = 5;
+    int Modifier;
     int Amount;
+    int Index;
 
-    if (RarityMax > 9)
-        RarityMax = 9;
+    // Calculate Modifier
+    if (GetCVar("drpg_loot_type") == 0)
+        Modifier = RoundInt(7.5 * MapLevelModifier + 7.5 * (fixed)AveragePlayerLuck() / 100.0);
+    if (GetCVar("drpg_loot_type") == 1)
+        Modifier = RoundInt(15.0 * MapLevelModifier);
+    if (GetCVar("drpg_loot_type") == 2)
+        Modifier = RoundInt(15.0 * (fixed)AveragePlayerLuck() / 100.0);
+    if (GetCVar("drpg_loot_type") == 3)
+        Modifier = Random(0,15);
+    if (Modifier > 15)
+        Modifier = 15;
+
+    // Calculate Rarity Max
+    for (int i = RarityMax; i < 10; i++)
+        if (Random(0, Random(3, 7) + RarityMax - Modifier) <= 0)
+            RarityMax++;
+    if (RarityMax < 5) // Make sure the Rarity still isn't -1, or else bad things will happen
+        RarityMax = 5;
+    if (RarityMax > 5 + RoundInt(5.0 * MapLevelModifier))
+        RarityMax = 5 + RoundInt(5.0 * MapLevelModifier);
+    if (RarityMax > 10)
+        RarityMax = 10;
+
+    // Calculate Rarity Min
+    if (RarityMax > 1)
+        RarityMin = Random(RarityMax / 4, RarityMax - 1);
 
     while (!ItemSpawned)
     {
-        Amount = 0;
-
         for (int i = 0; i < ItemMax[ItemCategory]; i++)
         {
-            if (StrMid(ItemData[ItemCategory][i].Name, StrLen(ItemData[ItemCategory][i].Name) - 9, 6) == "Unique" && ItemData[ItemCategory][i].Rarity >= RarityMin && ItemData[ItemCategory][i].Rarity <= RarityMax)
+            if (!ItemSpawned && StrMid(ItemData[ItemCategory][i].Name, StrLen(ItemData[ItemCategory][i].Name) - 9, 6) == "Unique" && ItemData[ItemCategory][i].Rarity >= RarityMin && ItemData[ItemCategory][i].Rarity <= RarityMax)
             {
-                if (Random(0, 1 + Amount) <= 0)
+                if (Random(0, (100 + (25 * Amount)) * (1 + ItemData[ItemCategory][i].Spawned * 4)) <= 50)
                 {
-                    ActorToSpawn = ItemData[ItemCategory][i].Actor;
+                    // Set weapon index
+                    Index = i;
+
+                    ActorToSpawn = StrParam("%SPickup", ItemData[ItemCategory][Index].Actor);
                     ItemSpawned = true;
                 }
                 Amount++;
             }
-            if (Amount > ItemMax[ItemCategory]) Amount = 0;
+
+            Amount = 0;
         }
     }
+
+    if (ItemSpawned)
+        ItemData[ItemCategory][Index].Spawned++;;
 
     SpawnSpotFacingForced(ActorToSpawn, 0, ActivatorTID());
 
@@ -1670,7 +1710,7 @@ NamedScript DECORATE void DRPGArmorSpawner(int Armor)
 
                 if (!ItemSpawned && ItemData[ItemCategory][j].Rarity >= RarityMin && ItemData[ItemCategory][j].Rarity <= RarityMax)
                 {
-                    if (Random(0, (100 + (25 * Amount)) * (1 + ItemData[ItemCategory][j].Dropped * 4)) <= 50)
+                    if (Random(0, (100 + (25 * Amount)) * (1 + ItemData[ItemCategory][j].Spawned * 4)) <= 50)
                     {
                         // Set armor index
                         Index = j;
@@ -1706,8 +1746,10 @@ NamedScript DECORATE void DRPGArmorSpawner(int Armor)
         {
             if (StrMid(ItemData[ItemCategory][Index].Name, StrLen(ItemData[ItemCategory][Index].Name) - 12, 9) == "Assembled")
             {
+                if ((ItemCategory == 3 && (Index == 22 || Index == 26 || Index == 27 || Index == 28)) || (ItemCategory == 9 && Index == 3))
+                    ActorToSpawn = StrParam("%SWorldSpawnPickup", StrLeft(ActorToSpawn, StrLen(ActorToSpawn) - 6));
                 Players(0).ArmorAssembledChance = 0;
-                ItemData[ItemCategory][Index].Dropped++;
+                ItemData[ItemCategory][Index].Spawned++;
             }
             else
                 Players(0).ArmorAssembledChance += 50.0 * (fixed)Modifier / 15.0;
@@ -1715,7 +1757,7 @@ NamedScript DECORATE void DRPGArmorSpawner(int Armor)
             if (StrMid(ItemData[ItemCategory][Index].Name, StrLen(ItemData[ItemCategory][Index].Name) - 9, 6) == "Exotic")
             {
                 Players(0).ArmorExoticChance = 0;
-                ItemData[ItemCategory][Index].Dropped++;
+                ItemData[ItemCategory][Index].Spawned++;
             }
             else
                 Players(0).ArmorExoticChance += 30.0 * (fixed)Modifier / 15.0;
@@ -1723,31 +1765,34 @@ NamedScript DECORATE void DRPGArmorSpawner(int Armor)
             if (StrMid(ItemData[ItemCategory][Index].Name, StrLen(ItemData[ItemCategory][Index].Name) - 11, 8) == "Superior")
             {
                 Players(0).ArmorSuperiorChance = 0;
-                ItemData[ItemCategory][Index].Dropped++;
+                ItemData[ItemCategory][Index].Spawned++;
             }
             else
                 Players(0).ArmorSuperiorChance += 0.5 * (fixed)Modifier / 15.0;
 
             if (StrMid(ItemData[ItemCategory][Index].Name, StrLen(ItemData[ItemCategory][Index].Name) - 9, 6) == "Unique")
             {
+                ActorToSpawn = StrParam("%SWorldSpawnPickup", StrLeft(ActorToSpawn, StrLen(ActorToSpawn) - 6));
                 Players(0).ArmorUniqueChance = 0;
-                ItemData[ItemCategory][Index].Dropped++;
+                ItemData[ItemCategory][Index].Spawned++;
             }
             else
                 Players(0).ArmorUniqueChance += 2.5 * (fixed)Modifier / 15.0;
 
             if (StrMid(ItemData[ItemCategory][Index].Name, StrLen(ItemData[ItemCategory][Index].Name) - 10, 7) == "Demonic")
             {
+                ActorToSpawn = StrParam("%SWorldSpawnPickup", StrLeft(ActorToSpawn, StrLen(ActorToSpawn) - 6));
                 Players(0).ArmorDemonicChance = 0;
-                ItemData[ItemCategory][Index].Dropped++;
+                ItemData[ItemCategory][Index].Spawned++;
             }
             else
                 Players(0).ArmorDemonicChance += 0.3 * (fixed)Modifier / 15.0;
 
             if (StrMid(ItemData[ItemCategory][Index].Name, StrLen(ItemData[ItemCategory][Index].Name) - 12, 9) == "Legendary")
             {
+                ActorToSpawn = StrParam("%SWorldSpawnPickup", StrLeft(ActorToSpawn, StrLen(ActorToSpawn) - 6));
                 Players(0).ArmorLegendaryChance = 0;
-                ItemData[ItemCategory][Index].Dropped++;
+                ItemData[ItemCategory][Index].Spawned++;
             }
             else
                 Players(0).ArmorLegendaryChance += 0.2 * (fixed)Modifier / 15.0;

--- a/DoomRPG/scripts/Menu.c
+++ b/DoomRPG/scripts/Menu.c
@@ -713,8 +713,6 @@ void DrawStatsMenu()
             HudMessage("Regen Sphere: %d Sec", (int)(40 + Player.RegenerationTotal * 2));
             EndHudMessage(HUDMSG_PLAIN, 0, "Purple",             30.1,   152.0,  0.05);
         }
-        HudMessage("Regen Sphere: %d Sec", (int)(40 + Player.RegenerationTotal * 2));
-        EndHudMessage(HUDMSG_PLAIN, 0, "Purple",             30.1,   152.0,  0.05);
         HudMessage("Toxicity Regen: %d Sec", 30 - Player.ToxicityRegenBonus);
         EndHudMessage(HUDMSG_PLAIN, 0, "Green",              30.1,   160.0,  0.05);
         HudMessage("Speed: %.2k", Player.Speed);

--- a/DoomRPG/scripts/Monsters.c
+++ b/DoomRPG/scripts/Monsters.c
@@ -3035,29 +3035,29 @@ NamedScript void MonsterDeath()
         // Auras have a chance of rare vial drops
         for (int i = 0; i < AURA_MAX; i++)
             if (Stats->Aura.Type[i].Active)
-                DropMonsterItem(Killer, 0, "DRPGVialDropperRare", 8 * DropMonsterModifier);
+                DropMonsterItem(Killer, 0, "DRPGVialDropperRare", 16 * DropMonsterModifier);
 
         // Aura Drops
         if (Stats->Aura.Type[AURA_RED].Active) // Red Aura - Strength
-            DropMonsterItem(Killer, 0, "DRPGVialDropper", 32 * DropMonsterModifier);
+            DropMonsterItem(Killer, 0, "DRPGVialDropper", 64 * DropMonsterModifier);
         if (Stats->Aura.Type[AURA_GREEN].Active) // Green Aura - Defense
-            DropMonsterItem(Killer, 0, "DRPGVialDropper", 32 * DropMonsterModifier);
+            DropMonsterItem(Killer, 0, "DRPGVialDropper", 64 * DropMonsterModifier);
         if (Stats->Aura.Type[AURA_WHITE].Active) // White Aura - XP
-            DropMonsterItem(Killer, 0, "DRPGVialDropper", 32 * DropMonsterModifier);
+            DropMonsterItem(Killer, 0, "DRPGVialDropper", 64 * DropMonsterModifier);
         if (Stats->Aura.Type[AURA_PINK].Active) // Pink Aura - Vitality
-            DropMonsterItem(Killer, 0, "DRPGVialDropper", 32 * DropMonsterModifier);
+            DropMonsterItem(Killer, 0, "DRPGVialDropper", 64 * DropMonsterModifier);
         if (Stats->Aura.Type[AURA_BLUE].Active) // Blue Aura - Energy
-            DropMonsterItem(Killer, 0, "DRPGVialDropper", 32 * DropMonsterModifier);
+            DropMonsterItem(Killer, 0, "DRPGVialDropper", 64 * DropMonsterModifier);
         if (Stats->Aura.Type[AURA_PURPLE].Active) // Purple Aura - Regeneration
-            DropMonsterItem(Killer, 0, "DRPGVialDropper", 32 * DropMonsterModifier);
+            DropMonsterItem(Killer, 0, "DRPGVialDropper", 64 * DropMonsterModifier);
         if (Stats->Aura.Type[AURA_ORANGE].Active) // Orange Aura - Agility
-            DropMonsterItem(Killer, 0, "DRPGVialDropper", 32 * DropMonsterModifier);
+            DropMonsterItem(Killer, 0, "DRPGVialDropper", 64 * DropMonsterModifier);
         if (Stats->Aura.Type[AURA_DARKBLUE].Active) // Dark Blue Aura - Capacity
-            DropMonsterItem(Killer, 0, "DRPGVialDropper", 32 * DropMonsterModifier);
+            DropMonsterItem(Killer, 0, "DRPGVialDropper", 64 * DropMonsterModifier);
         if (Stats->Aura.Type[AURA_YELLOW].Active) // Yellow Aura - Luck
         {
-            DropMonsterItem(Killer, 0, "DRPGVialDropper", 32 * DropMonsterModifier);
-            DropMonsterItem(Killer, 0, "DRPGChipDropper", 32 * DropMonsterModifier);
+            DropMonsterItem(Killer, 0, "DRPGVialDropper", 64 * DropMonsterModifier);
+            DropMonsterItem(Killer, 0, "DRPGChipDropper", 64 * DropMonsterModifier);
         }
 
         // Luck-based Drops

--- a/DoomRPG/scripts/Outpost.c
+++ b/DoomRPG/scripts/Outpost.c
@@ -2716,7 +2716,7 @@ NamedScript MapSpecial void DisassemblingDevice()
 
                         SetFont("SMALLFONT");
                         HudMessage("Cost of Extraction:");
-                        EndHudMessage(HUDMSG_FADEOUT, MENU_ID + 7, "White", X + 288.0, Y + 336.0, 0.05, 0.05);
+                        EndHudMessage(HUDMSG_FADEOUT, MENU_ID + 7, "White", X + 292.0, Y + 336.0, 0.05, 0.05);
 
                         SetFont("BIGFONT");
                         HudMessage("\Cf%d C\C-", CurrentExtractionCost);
@@ -2724,7 +2724,7 @@ NamedScript MapSpecial void DisassemblingDevice()
 
                         SetFont("SMALLFONT");
                         HudMessage("\Ck(Discount: %d%%)", Player.ShopDiscount);
-                        EndHudMessage(HUDMSG_FADEOUT, MENU_ID + 9, "White", X + 304.0, Y + 400.0, 0.05, 0.05);
+                        EndHudMessage(HUDMSG_FADEOUT, MENU_ID + 9, "White", X + 308.0, Y + 400.0, 0.05, 0.05);
 
                         SetFont("SMALLFONT");
                         HudMessage("Possible Extraction:\n\nMaximum amount: \Cd%d pcs.\C-", MaxAmount);
@@ -3525,7 +3525,7 @@ NamedScript MapSpecial void DisassemblingDevice()
                             CurrentAmountDetails4 = 1;
 
                             // Calculate Current Cost
-                            CurrentCost = (Item->Price - Item->Price * Player.ShopDiscount / 100) / 250 * 250;
+                            CurrentCost = ((Item->Price - Item->Price * Player.ShopDiscount / 100) / 2) / 250 * 250;
 
                             // Calculate Amount Details
                             CurrentAmountDetails1 = (int)(Curve(Item->Price / 20, CurrentCostMin, CurrentCostMax, 30, 120)) / 5 * 5;
@@ -3533,26 +3533,61 @@ NamedScript MapSpecial void DisassemblingDevice()
                             CurrentAmountDetails3 = (int)(Curve(Item->Price / 20, CurrentCostMin, CurrentCostMax, 10, 40)) / 5 * 5;
 
                             // Set Individual Required
-                            // For Trigun
-                            if (ItemData[0][CurrentItem].Actor == "RLTrigun")
+                            // For Grammaton Cleric Beretta
+                            if (ItemData[0][CurrentItem].Actor == "RLGrammatonClericBeretta")
                             {
-                                CurrentIndexBasic = 75;
+                                CurrentIndexBasic = 11;
                             }
                             // For Widowmaker SMG
                             if (ItemData[0][CurrentItem].Actor == "RLWidowmakerSMG")
                             {
                                 CurrentIndexBasic = 6;
-                                CurrentAmountDetails1 *= 2;
-                                CurrentAmountDetails2 *= 2;
-                                CurrentAmountDetails3 *= 2;
+                                CurrentAmountDetails1 = 45;
+                                CurrentAmountDetails2 = 30;
+                                CurrentAmountDetails3 = 15;
+                            }
+                            // For Revenant's Launcher
+                            if (ItemData[0][CurrentItem].Actor == "RLRevenantsLauncher")
+                            {
+                                CurrentIndexBasic = -1;
+                                CurrentTypeDetails1 =  12;
+                                CurrentTypeDetails2 =  8;
+                                CurrentAmountDetails1 = 60;
+                                CurrentAmountDetails2 = 40;
+                                CurrentAmountDetails3 = 20;
+                            }
+                            // For Plasma Redirection Cannon
+                            if (ItemData[0][CurrentItem].Actor == "RLPlasmaRedirectionCannon")
+                            {
+                                CurrentIndexBasic = 9;
+                                CurrentTypeDetails2 =  10;
+                                CurrentTypeDetails3 =  11;
+                                CurrentTypeDetails5 =  13;
+                                CurrentTypeDetails6 =  30;
+                                CurrentAmountDetails5 = 1;
+                                CurrentAmountDetails6 = 2;
+                            }
+                            // For Trigun
+                            if (ItemData[0][CurrentItem].Actor == "RLTrigun")
+                            {
+                                CurrentIndexBasic = 75;
+                            }
+                            // For Chameleon Rifle
+                            if (ItemData[0][CurrentItem].Actor == "RLChameleonRifle")
+                            {
+                                CurrentIndexBasic = 98;
+                                CurrentTypeDetails3 =  11;
+                                CurrentTypeDetails5 =  11;
+                                CurrentAmountDetails1 = 40;
+                                CurrentAmountDetails5 = 1;
                             }
                             // For Frag Shotgun
                             if (ItemData[0][CurrentItem].Actor == "RLFragShotgun")
                             {
                                 CurrentIndexBasic = 2;
-                                CurrentAmountDetails1 *= 2;
-                                CurrentAmountDetails2 *= 2;
-                                CurrentAmountDetails3 *= 2;
+                                CurrentAmountDetails1 = 50;
+                                CurrentAmountDetails2 = 30;
+                                CurrentAmountDetails3 = 20;
                             }
                             // For Railgun
                             if (ItemData[0][CurrentItem].Actor == "RLRailgun")
@@ -3562,86 +3597,21 @@ NamedScript MapSpecial void DisassemblingDevice()
                                 CurrentTypeDetails3 =  11;
                                 CurrentTypeDetails6 =  30;
                                 CurrentAmountDetails6 = 1;
-                                CurrentAmountDetails1 *= 2;
-                                CurrentAmountDetails2 *= 2;
-                                CurrentAmountDetails3 *= 2;
+                                CurrentAmountDetails1 = 50;
+                                CurrentAmountDetails2 = 30;
+                                CurrentAmountDetails3 = 20;
                             }
-                            // For Revenant's Launcher
-                            if (ItemData[0][CurrentItem].Actor == "RLRevenantsLauncher")
+                            // For Hellsing ARMS Casull
+                            if (ItemData[0][CurrentItem].Actor == "RLHellsingARMSCasull")
                             {
-                                CurrentIndexBasic = -1;
-                                CurrentTypeDetails1 =  12;
-                                CurrentAmountDetails1 = 60;
-                                CurrentTypeDetails2 =  8;
-                                CurrentAmountDetails2 *= 2;
-                                CurrentAmountDetails3 *= 2;
-                            }
-                            // For Grammaton Cleric Beretta
-                            if (ItemData[0][CurrentItem].Actor == "RLGrammatonClericBeretta")
-                            {
-                                CurrentIndexBasic = 102;
-                            }
-                            // For Jackhammer
-                            if (ItemData[0][CurrentItem].Actor == "RLJackhammer")
-                            {
-                                CurrentIndexBasic = 15;
-                            }
-                            // For Steel Beast
-                            if (ItemData[0][CurrentItem].Actor == "RLSteelBeast")
-                            {
-                                CurrentIndexBasic = 89;
-                                CurrentTypeDetails5 =  11;
-                                CurrentAmountDetails5 = 1;
-                            }
-                            // For Plasma Redirection Cannon
-                            if (ItemData[0][CurrentItem].Actor == "RLPlasmaRedirectionCannon")
-                            {
-                                CurrentIndexBasic = 23;
-                                CurrentTypeDetails2 =  10;
-                                CurrentTypeDetails3 =  11;
-                                CurrentTypeDetails5 =  13;
-                                CurrentAmountDetails5 = 1;
-                                CurrentTypeDetails6 =  30;
-                                CurrentAmountDetails6 = 2;
-                            }
-                            // For Mysterious Magnum
-                            if (ItemData[0][CurrentItem].Actor == "RLMysteriousMagnum")
-                            {
-                                CurrentIndexBasic = 75;
-                            }
-                            // For Nanomachic Armament Generator
-                            if (ItemData[0][CurrentItem].Actor == "RLNanomachicArmamentGenerator")
-                            {
-                                CurrentIndexBasic = 199;
-                                CurrentTypeDetails5 =  11;
-                                CurrentAmountDetails5 = 1;
-                            }
-                            // For Charch's Null Pointer
-                            if (ItemData[0][CurrentItem].Actor == "RLNullPointer")
-                            {
-                                CurrentIndexBasic = 37;
-                                CurrentTypeDetails2 =  10;
-                                CurrentTypeDetails3 =  11;
+                                CurrentIndexBasic = 13;
                                 CurrentTypeDetails5 =  14;
                                 CurrentAmountDetails5 = 1;
-                                CurrentTypeDetails6 =  30;
-                                CurrentAmountDetails6 = 1;
-                            }
-                            // For Suss Gun
-                            if (ItemData[0][CurrentItem].Actor == "RLSussGun")
-                            {
-                                CurrentIndexBasic = 23;
-                                CurrentTypeDetails5 =  12;
-                                CurrentTypeDetails2 =  10;
-                                CurrentTypeDetails3 =  11;
-                                CurrentAmountDetails5 = 1;
-                                CurrentTypeDetails6 =  30;
-                                CurrentAmountDetails6 = 4;
                             }
                             // For MA-75B Assault Rifle
                             if (ItemData[0][CurrentItem].Actor == "RLMarathonAssaultRifle")
                             {
-                                CurrentIndexBasic = 98;
+                                CurrentIndexBasic = 6;
                                 CurrentTypeDetails5 =  11;
                                 CurrentAmountDetails5 = 1;
                             }
@@ -3652,25 +3622,18 @@ NamedScript MapSpecial void DisassemblingDevice()
                                 CurrentTypeDetails5 =  11;
                                 CurrentAmountDetails5 = 1;
                             }
-                            // For Anti-Freak Jackal
-                            if (ItemData[0][CurrentItem].Actor == "RLAntiFreakJackal")
+                            // For Jackhammer
+                            if (ItemData[0][CurrentItem].Actor == "RLJackhammer")
                             {
-                                CurrentIndexBasic = 104;
-                                CurrentTypeDetails5 =  14;
-                                CurrentAmountDetails5 = 1;
+                                CurrentIndexBasic = 15;
+                                CurrentAmountDetails1 = 60;
+                                CurrentAmountDetails2 = 40;
+                                CurrentAmountDetails3 = 20;
                             }
-                            // For Hellsing ARMS Casull
-                            if (ItemData[0][CurrentItem].Actor == "RLHellsingARMSCasull")
+                            // For Steel Beast
+                            if (ItemData[0][CurrentItem].Actor == "RLSteelBeast")
                             {
-                                CurrentIndexBasic = 104;
-                                CurrentTypeDetails5 =  14;
-                                CurrentAmountDetails5 = 1;
-                            }
-                            // For Unknown Herald
-                            if (ItemData[0][CurrentItem].Actor == "RLUnknownHerald")
-                            {
-                                CurrentIndexBasic = 104;
-                                CurrentTypeDetails2 =  8;
+                                CurrentIndexBasic = 89;
                                 CurrentTypeDetails5 =  11;
                                 CurrentAmountDetails5 = 1;
                             }
@@ -3681,28 +3644,77 @@ NamedScript MapSpecial void DisassemblingDevice()
                                 CurrentTypeDetails2 =  10;
                                 CurrentTypeDetails3 =  11;
                                 CurrentTypeDetails5 =  12;
-                                CurrentAmountDetails5 = 1;
                                 CurrentTypeDetails6 =  29;
+                                CurrentAmountDetails5 = 1;
                                 CurrentAmountDetails6 = 6;
                             }
-                            // For Particle Beam Cannon
-                            if (ItemData[0][CurrentItem].Actor == "RLParticleBeamCannon")
+                            // For Mysterious Magnum
+                            if (ItemData[0][CurrentItem].Actor == "RLMysteriousMagnum")
                             {
-                                CurrentIndexBasic = 37;
+                                CurrentIndexBasic = 75;
+                            }
+                            // For Unknown Herald
+                            if (ItemData[0][CurrentItem].Actor == "RLUnknownHerald")
+                            {
+                                CurrentIndexBasic = 12;
+                                CurrentTypeDetails2 =  8;
+                                CurrentTypeDetails5 =  12;
+                                CurrentAmountDetails5 = 1;
+                            }
+                            // For Nanomachic Armament Generator
+                            if (ItemData[0][CurrentItem].Actor == "RLNanomachicArmamentGenerator")
+                            {
+                                CurrentIndexBasic = 199;
+                                CurrentTypeDetails5 =  11;
+                                CurrentAmountDetails5 = 1;
+                            }
+                            // For Suss Gun
+                            if (ItemData[0][CurrentItem].Actor == "RLSussGun")
+                            {
+                                CurrentIndexBasic = 20;
+                                CurrentTypeDetails5 =  12;
                                 CurrentTypeDetails2 =  10;
                                 CurrentTypeDetails3 =  11;
-                                CurrentTypeDetails5 =  13;
                                 CurrentAmountDetails5 = 1;
                                 CurrentTypeDetails6 =  30;
-                                CurrentAmountDetails6 = 2;
+                                CurrentAmountDetails6 = 4;
+                            }
+                            // For Charch's Null Pointer
+                            if (ItemData[0][CurrentItem].Actor == "RLNullPointer")
+                            {
+                                CurrentIndexBasic = 41;
+                                CurrentTypeDetails2 =  10;
+                                CurrentTypeDetails3 =  11;
+                                CurrentTypeDetails5 =  14;
+                                CurrentAmountDetails5 = 1;
+                                CurrentTypeDetails6 =  30;
+                                CurrentAmountDetails6 = 1;
                             }
                             // For MIRV Launcher
                             if (ItemData[0][CurrentItem].Actor == "RLMIRVLauncher")
                             {
                                 CurrentIndexBasic = 18;
                                 CurrentTypeDetails2 =  8;
-                                CurrentTypeDetails5 =  11;
+                                CurrentTypeDetails5 =  12;
                                 CurrentAmountDetails5 = 1;
+                            }
+                            // For Anti-Freak Jackal
+                            if (ItemData[0][CurrentItem].Actor == "RLAntiFreakJackal")
+                            {
+                                CurrentIndexBasic = 104;
+                                CurrentTypeDetails5 =  14;
+                                CurrentAmountDetails5 = 1;
+                            }
+                            // For Particle Beam Cannon
+                            if (ItemData[0][CurrentItem].Actor == "RLParticleBeamCannon")
+                            {
+                                CurrentIndexBasic = 41;
+                                CurrentTypeDetails2 =  10;
+                                CurrentTypeDetails3 =  11;
+                                CurrentTypeDetails5 =  13;
+                                CurrentAmountDetails5 = 1;
+                                CurrentTypeDetails6 =  30;
+                                CurrentAmountDetails6 = 2;
                             }
                             // For BFG10k
                             if (ItemData[0][CurrentItem].Actor == "RLBFG10k")
@@ -3714,13 +3726,6 @@ NamedScript MapSpecial void DisassemblingDevice()
                                 CurrentAmountDetails5 = 1;
                                 CurrentTypeDetails6 =  30;
                                 CurrentAmountDetails6 = 2;
-                            }
-                            // For Chameleon Rifle
-                            if (ItemData[0][CurrentItem].Actor == "RLChameleonRifle")
-                            {
-                                CurrentIndexBasic = 98;
-                                CurrentTypeDetails5 =  11;
-                                CurrentAmountDetails5 = 1;
                             }
                             // For Quad Shotgun
                             if (ItemData[0][CurrentItem].Actor == "RLQuadShotgun")
@@ -3743,7 +3748,7 @@ NamedScript MapSpecial void DisassemblingDevice()
                             // For Lucifer Cannon
                             if (ItemData[0][CurrentItem].Actor == "RLLuciferCannon")
                             {
-                                CurrentIndexBasic = 37;
+                                CurrentIndexBasic = 41;
                                 CurrentTypeDetails2 =  10;
                                 CurrentTypeDetails3 =  11;
                                 CurrentTypeDetails5 =  14;
@@ -3754,7 +3759,7 @@ NamedScript MapSpecial void DisassemblingDevice()
                             {
                                 CurrentIndexBasic = 18;
                                 CurrentTypeDetails2 =  8;
-                                CurrentTypeDetails5 =  11;
+                                CurrentTypeDetails5 =  12;
                                 CurrentAmountDetails5 = 1;
                             }
                             // For Nuclear Onslaught
@@ -4084,6 +4089,14 @@ NamedScript MapSpecial void DisassemblingDevice()
                             {
                                 CurrentIndexBasic = 18;
                                 CurrentTypeDetails2 =  8;
+                                CurrentTypeDetails5 =  12;
+                                CurrentAmountDetails5 = 1;
+                            }
+                            // For 0D-1a Assaultforce Armor
+                            if (ItemData[3][CurrentItem].Actor == "RLZeroDiamondAssaultforceArmorPickup")
+                            {
+                                CurrentIndexBasic = 18;
+                                CurrentTypeDetails2 =  6;
                                 CurrentTypeDetails5 =  11;
                                 CurrentAmountDetails5 = 1;
                             }
@@ -4117,14 +4130,6 @@ NamedScript MapSpecial void DisassemblingDevice()
                                 CurrentIndexBasic = 41;
                                 CurrentTypeDetails6 = 30;
                                 CurrentAmountDetails6 = 2;
-                            }
-                            // For 0D-1a Assaultforce Armor
-                            if (ItemData[3][CurrentItem].Actor == "RLZeroDiamondAssaultforceArmorPickup")
-                            {
-                                CurrentIndexBasic = 18;
-                                CurrentTypeDetails2 =  6;
-                                CurrentTypeDetails5 =  11;
-                                CurrentAmountDetails5 = 1;
                             }
                             // For Malek's Armor
                             if (ItemData[3][CurrentItem].Actor == "RLMaleksArmorPickup")
@@ -4560,6 +4565,7 @@ NamedScript MapSpecial void DisassemblingDevice()
                                     && CheckInventory(ItemData[7][CurrentTypeDetails3].Actor) >= CurrentAmountDetails3 && CheckInventory(ItemData[8][CurrentTypeDetails4].Actor) >= CurrentAmountDetails4 && CheckInventory(ItemData[4][CurrentTypeDetails5].Actor) >= CurrentAmountDetails5 && CheckInventory(ItemData[6][CurrentTypeDetails6].Actor) >= CurrentAmountDetails6)
                             {
                                 Player.OutpostMenu = 0;
+                                str ActorToSpawn;
 
                                 // Take Basic Item
                                 if (CurrentIndexBasic >= 0)
@@ -4585,8 +4591,13 @@ NamedScript MapSpecial void DisassemblingDevice()
                                 FadeRange(0, 0, 0, 0.5, 0, 0, 0, 1.0, 1.0);
                                 Delay(35 * 1);
 
+                                // Set actor to spawn
+                                ActorToSpawn = ItemData[CategoriesData[CurrentCategory]][CurrentItem].Actor;
+                                if (CompatMode == COMPAT_DRLA && CurrentCategory == 0)
+                                    ActorToSpawn = StrParam("%SPickup", ActorToSpawn);
+
                                 // Spawn Item in Disassembling Device
-                                SpawnSpotForced(ItemData[CategoriesData[CurrentCategory]][CurrentItem].Actor, DisassemblingDeviceID, UniqueTID(), 0);
+                                SpawnSpotForced(ActorToSpawn, DisassemblingDeviceID, UniqueTID(), 0);
 
                                 SetFont("BIGFONT");
                                 HudMessage("Item assembly is complete");
@@ -5067,6 +5078,7 @@ NamedScript MapSpecial void DemonAssemblingSanctuary()
                         && CheckInventory(ItemData[7][CurrentTypeDetails3].Actor) >= CurrentAmountDetails3 && CheckInventory(ItemData[8][CurrentTypeDetails4].Actor) >= CurrentAmountDetails4 && CheckInventory(ItemData[4][CurrentTypeDetails5].Actor) >= CurrentAmountDetails5 && CheckInventory(ItemData[6][CurrentTypeDetails6].Actor) >= CurrentAmountDetails6)
                 {
                     Player.OutpostMenu = 0;
+                    str ActorToSpawn;
 
                     // Take Basic Item
                     if (CurrentIndexBasic >= 0)
@@ -5096,8 +5108,13 @@ NamedScript MapSpecial void DemonAssemblingSanctuary()
                     FadeRange(0, 0, 0, 0.5, 0, 0, 0, 1.0, 1.0);
                     Delay(35 * 1);
 
+                    // Set actor to spawn
+                    ActorToSpawn = ItemData[CategoriesData[CurrentCategory]][CurrentItem].Actor;
+                    if (CompatMode == COMPAT_DRLA && CurrentCategory == 0)
+                        ActorToSpawn = StrParam("%SPickup", ActorToSpawn);
+
                     // Spawn Item in Disassembling Device
-                    SpawnSpotForced(ItemData[CategoriesData[CurrentCategory]][CurrentItem].Actor, DemonSanctuaryID, UniqueTID(), 0);
+                    SpawnSpotForced(ActorToSpawn, DemonSanctuaryID, UniqueTID(), 0);
 
                     SetFont("BIGFONT");
                     HudMessage("Item summoning is complete");

--- a/DoomRPG/scripts/Shield.c
+++ b/DoomRPG/scripts/Shield.c
@@ -1047,8 +1047,8 @@ NamedScript void SanicMod()
 
 NamedScript void NakedMod()
 {
-    if (Player.Shield.Active && CheckInventory("Armor") > 0)
-        GiveInventory("DRPGShieldNakedResist", 1);
+    if (Player.Shield.Active && CheckInventory("Armor") <= 0)
+        Player.DamageFactor *= 0.75;
 }
 
 NamedScript void BloodyShieldSoRealMod()

--- a/DoomRPG/scripts/Utils.c
+++ b/DoomRPG/scripts/Utils.c
@@ -1363,10 +1363,8 @@ fixed StatsNatMod()
         // Skip player if they're not ingame
         if (!PlayerInGame(i)) continue;
 
-        PlayerLevel = Players(i).Level;
-        if (PlayerLevel <= 0) PlayerLevel = 1;
         StatsNat = Players(i).StrengthNat + Players(i).DefenseNat + Players(i).VitalityNat + Players(i).EnergyNat + Players(i).RegenerationNat + Players(i).AgilityNat + Players(i).CapacityNat + Players(i).LuckNat;
-        Modifier += ((fixed)StatsNat / ((fixed)PlayerLevel * 8.0) > 1.0 ? 1.0 : (fixed)StatsNat / ((fixed)PlayerLevel * 8.0));
+        Modifier += (fixed)StatsNat / 800.0 > 1.0 ? 1.0 : (fixed)StatsNat / 800.0;
         NumPlayers++;
     }
 
@@ -3928,30 +3926,29 @@ NamedScript void Silly()
 
 NamedScript Console void Test()
 {
-    /*  // For test the drop system
-        if (DebugLog)
-        {
-            Log("------------------------------------");
-            Log("Weapon dropped:");
-            for (int i = 0; i < ItemMax[0]; i++)
-                if (ItemData[0][i].Dropped > 0)
-                    Log("Item #%d. %S - %d dropped", i, ItemData[0][i].Name, ItemData[0][i].Dropped);
+    // For test the drop system
+    if (DebugLog)
+    {
+        Log("------------------------------------");
+        Log("Weapon dropped:");
+        for (int i = 0; i < ItemMax[0]; i++)
+            if (ItemData[0][i].Spawned > 0)
+                Log("Item #%d. %S - %d dropped", i, ItemData[0][i].Name, ItemData[0][i].Spawned);
 
-            Log("------------------------------------");
-            Log("Armors dropped:");
-            for (int j = 0; j < ItemMax[3]; j++)
-                if (ItemData[3][j].Dropped > 0)
-                    Log("Item #%d. %S - %d dropped", j, ItemData[3][j].Name, ItemData[3][j].Dropped);
+        Log("------------------------------------");
+        Log("Armors dropped:");
+        for (int j = 0; j < ItemMax[3]; j++)
+            if (ItemData[3][j].Spawned > 0)
+                Log("Item #%d. %S - %d dropped", j, ItemData[3][j].Name, ItemData[3][j].Spawned);
 
-            Log("------------------------------------");
-            Log("Boots dropped:");
-            for (int k = 0; k < ItemMax[9]; k++)
-                if (ItemData[9][k].Dropped > 0)
-                    Log("Item #%d. %S - %d dropped", k, ItemData[9][k].Name, ItemData[9][k].Dropped);
+        Log("------------------------------------");
+        Log("Boots dropped:");
+        for (int k = 0; k < ItemMax[9]; k++)
+            if (ItemData[9][k].Spawned > 0)
+                Log("Item #%d. %S - %d dropped", k, ItemData[9][k].Name, ItemData[9][k].Spawned);
 
-            Log("------------------------------------");
-        }
-    */
+        Log("------------------------------------");
+    }
 
     Log("Test is work!");
 }

--- a/DoomRPG/scripts/inc/Structs.h
+++ b/DoomRPG/scripts/inc/Structs.h
@@ -164,7 +164,7 @@ struct ItemInfo_S
     int Category;
     int Index;
 
-    int Dropped;
+    int Spawned;
 };
 
 // Crates

--- a/DoomRPG/zscript/DRPGZHandler.zs
+++ b/DoomRPG/zscript/DRPGZHandler.zs
@@ -67,13 +67,13 @@ class DRPGZEHandler : EventHandler
             Sector CurrSec = level.Sectors[i];
             secplane Floor = CurrSec.floorplane;
             secplane Ceiling = CurrSec.ceilingplane;
-            int ceilingZ = int(Ceiling.ZAtPoint((CurrSec.CenterSpot.x, CurrSec.CenterSpot.y)));
-            int floorZ = int(Floor.ZAtPoint((CurrSec.CenterSpot.x, CurrSec.CenterSpot.y)));
-            int centerHeight = ceilingZ - floorZ;
+            int CeilingZ = int(Ceiling.ZAtPoint((CurrSec.CenterSpot.x, CurrSec.CenterSpot.y)));
+            int FloorZ = int(Floor.ZAtPoint((CurrSec.CenterSpot.x, CurrSec.CenterSpot.y)));
+            int CenterHeight = CeilingZ - FloorZ;
             vector3 SpawnPos = (CurrSec.CenterSpot.x + random(-16, 16), CurrSec.CenterSpot.y + random(-16, 16), Floor.ZAtPoint(CurrSec.CenterSpot));
 
-            // Spawn Crate in a secret with a 20% chance, only if secret's sector is not a door (looking at you, Doom 1)
-            if (CurrSec.IsSecret() && centerHeight > 0)
+            // Spawn Crate in a secret with a certain chance, only if secret's sector is not a door (looking at you, Doom 1)
+            if (CurrSec.IsSecret() && CenterHeight > 0)
             {
                 Actor.Spawn("DRPGSecretSpawner", SpawnPos);
             }


### PR DESCRIPTION
DoomRL Arsenal compatibility:
- restored the function by which on the maps where appeared a unique or similar items - appears hinting to this message on the left to the top of the screen (pay attention to this to find something special);
- now each found unique or similar item increases the Danger Level (as in the original). Danger Level can be seen in the DoomRPG menu on the maps;
- Unique and Exotic weapons rearranged by priority of appearance/dropout;
- some recipes for crafting weapons through Dissasembling Device have been changed;
- fix: display HUD icons for Hellsing ARMS Casull and Anti Freak Jackal  when taken together;
- fix: megasphere now gives double the player's health (previously it was at 200 HP);
- fix: megasphere now gives energy points;

DoomRPG:
- changed the Natural Stats Leveling coefficient formula for monsters. Now monsters don't have to become infinitely stronger over time;
- increased the chance of dropping Vials from monsters with auras;
- fix: the "WRP30-LITE" energy shield accessory now works as described;
- fix: display the time of use of Regen Spheres in the DoomRPG menu.