### PR TITLE
Update 1.31g Hotfix 4

### DIFF
--- a/DoomRPG/GAMEINFO.txt
+++ b/DoomRPG/GAMEINFO.txt
@@ -1,3 +1,3 @@
-startuptitle = "Doom RPG SE Rebalance (2023-03-16)"
+startuptitle = "Doom RPG SE Rebalance (2023-03-17)"
 startupcolors = "0092FF", "000000"
 startuptype = "Hexen"

--- a/DoomRPG/TEXTURES.txt
+++ b/DoomRPG/TEXTURES.txt
@@ -54,6 +54,9 @@ Graphic L1UPB0, 26, 54 { Offset 0, 6 XScale 1.75 YScale 1.5 Graphic P1UBB0, 0, 0
 Graphic L1UPC0, 26, 54 { Offset 0, 6 XScale 1.75 YScale 1.5 Graphic P1UBC0, 0, 0 }
 Graphic L1UPD0, 26, 54 { Offset 0, 6 XScale 1.75 YScale 1.5 Graphic P1UBD0, 0, 0 }
 
+// Chemicals (for shop)
+Graphic LT02CH, 21, 34 { Offset 11, 33 XScale 1.5 YScale 1.5 Graphic LT02A0, 0, 0 }
+
 // Basic Shield Package
 Sprite SHPAA0, 32, 32
 {

--- a/DoomRPG/actors/Monsters.txt
+++ b/DoomRPG/actors/Monsters.txt
@@ -549,9 +549,6 @@ actor DRPGEnemyClearTarget2 : CustomInventory
     }
 }
 
-// Token for monsters revived by friendly Archvile
-actor DRPGFriendlyReviveMonster : Inventory {}
-
 // Red Aura Giver
 actor DRPGRedAuraGiver : CustomInventory
 {

--- a/DoomRPG/scripts/ItemData.c
+++ b/DoomRPG/scripts/ItemData.c
@@ -357,7 +357,7 @@ NamedScript void BuildItemData()
     // Generic Loot
     ITEMDATA_CATEGORY(7, "\CfLoot", CF_NOBUY | CF_NODROP);
     ITEMDATA_DEF("DRPGLootMedicalSupplies",     "Medical Supplies",     100, 0, -1, "LT01A0",  7, 15);
-    ITEMDATA_DEF("DRPGLootChemicals",           "Chemicals",            250, 0, -1, "LT02A0", 11, 34);
+    ITEMDATA_DEF("DRPGLootChemicals",           "Chemicals",            250, 0, -1, "LT02CH",  7, 23);
     ITEMDATA_DEF("DRPGLootHazardousMaterials",  "Hazardous Materials",  250, 0, -1, "LT03A0", 14, 19);
     ITEMDATA_DEF("DRPGLootAnomalousMaterials",  "Anomalous Materials",  250, 0, -1, "LT04A0",  5, 20);
     ITEMDATA_DEF("DRPGLootBriefcase",           "Briefcase Data",       500, 0, -1, "LT05A0", 14, 18);

--- a/DoomRPG/scripts/Menu.c
+++ b/DoomRPG/scripts/Menu.c
@@ -1335,6 +1335,43 @@ void DrawAugsMenu()
         }
 }
 
+ItemInfoPtr GetIncreaseSkillAddItem(int SkillCategory, int SkillIndex, int SkillLevel)
+{
+    // Get additional item for Summoning category
+    if (Player.SkillPage == 4)
+    {
+        if (Player.MenuIndex > 0) return FindItem("DRPGLootDemonArtifact"); // For Demons
+    }
+}
+
+int GetIncreaseSkillAddCost(int SkillCategory, int SkillIndex, int SkillLevel)
+{
+    int Amount;
+
+    // Get ammount additional items for Summoning category
+    if (Player.SkillPage == 4)
+    {
+        if (Player.MenuIndex == 1) Amount = 1;   // For Former Human
+        if (Player.MenuIndex == 2) Amount = 1;   // For Sergeant
+        if (Player.MenuIndex == 3) Amount = 2;   // For Commando
+        if (Player.MenuIndex == 4) Amount = 2;   // For Imp
+        if (Player.MenuIndex == 5) Amount = 2;   // For Demon
+        if (Player.MenuIndex == 6) Amount = 3;   // For Cacodemon
+        if (Player.MenuIndex == 7) Amount = 3;   // For Hell Knight
+        if (Player.MenuIndex == 8) Amount = 5;   // For Baron of Hell
+        if (Player.MenuIndex == 9) Amount = 1;   // For Loast Soul
+        if (Player.MenuIndex == 10) Amount = 5;  // For Pain Elemental
+        if (Player.MenuIndex == 11) Amount = 5;  // For Revenant
+        if (Player.MenuIndex == 12) Amount = 7;  // For Mancubus
+        if (Player.MenuIndex == 13) Amount = 7;  // For Arachnotron
+        if (Player.MenuIndex == 14) Amount = 10; // For Archvile
+        if (Player.MenuIndex == 15) Amount = 15; // For Cyberdemon
+        if (Player.MenuIndex == 16) Amount = 20; // For Spider Mastermind
+    }
+
+    return Amount * (SkillLevel + 1);
+}
+
 void DrawSkillMenu()
 {
     // Skill Catagories
@@ -1348,10 +1385,15 @@ void DrawSkillMenu()
         "\CcUtility"
     };
 
+    fixed YOffset;
     SkillPtr CurrentSkill = &Skills[Player.SkillPage][Player.MenuIndex];
     SkillLevelInfo *SkillLevel = &Player.SkillLevel[Player.SkillPage][Player.MenuIndex];
     int SkillCost = ScaleEPCost(CurrentSkill->Cost * SkillLevel->CurrentLevel);
     int SkillCostNext = ScaleEPCost(CurrentSkill->Cost * (SkillLevel->CurrentLevel + 1));
+
+    // Set variables for an additional item
+    ItemInfoPtr  AdditionalItem = GetIncreaseSkillAddItem(Player.SkillPage, Player.MenuIndex, SkillLevel->Level);
+    int AdditionalItemAmount = GetIncreaseSkillAddCost(Player.SkillPage, Player.MenuIndex, SkillLevel->Level);
 
     // Hold EP cost of skill "Magnetize"
     if (CurrentSkill->Name == "Magnetize")
@@ -1367,52 +1409,75 @@ void DrawSkillMenu()
     EndHudMessage(HUDMSG_PLAIN, 0, "White", 0.1, 25.0, 0.05);
 
     // Upgrade Modules
-    PrintSprite("UMODA0", 0, 232.1, 64.1, 0.05);
-    SetFont("BIGFONT");
     if (SkillLevel->Level < CurrentSkill->MaxLevel)
     {
-        HudMessage("%d \Cg(-%d)", CheckInventory("DRPGModule"), (int)((((fixed)SkillLevel->Level + 1) * (fixed)MODULE_SKILL_MULT) * GetCVarFixed("drpg_module_skillfactor")));
-        EndHudMessage(HUDMSG_PLAIN, 0, "Green", 256.1, 54.0, 0.05);
+        YOffset += 32.0;
+        PrintSprite("UMODA0", 0, 232.1, 32.1 + YOffset, 0.05);
+        SetFont("BIGFONT");
+        if (SkillLevel->Level < CurrentSkill->MaxLevel)
+        {
+            HudMessage("%d \Cg(-%d)", CheckInventory("DRPGModule"), (int)((((fixed)SkillLevel->Level + 1) * (fixed)MODULE_SKILL_MULT) * GetCVarFixed("drpg_module_skillfactor")));
+            EndHudMessage(HUDMSG_PLAIN, 0, "Green", 256.1, 22.0 + YOffset, 0.05);
+        }
+        else
+        {
+            HudMessage("%d", CheckInventory("DRPGModule"));
+            EndHudMessage(HUDMSG_PLAIN, 0, "Green", 256.1, 22.0 + YOffset, 0.05);
+        }
     }
-    else
+
+    // Additional items
+    if (SkillLevel->Level < CurrentSkill->MaxLevel && AdditionalItemAmount > 0)
     {
-        HudMessage("%d", CheckInventory("DRPGModule"));
-        EndHudMessage(HUDMSG_PLAIN, 0, "Green", 256.1, 54.0, 0.05);
+        YOffset += 32.0;
+        str TextColor = (Player.SkillPage == 4 && Player.MenuIndex > 0 ? "Brick" : "White");
+        PrintSprite(AdditionalItem->Sprite.Name, 0, 232.1, 32.1 + YOffset, 0.05);
+        SetFont("BIGFONT");
+        if (SkillLevel->Level < CurrentSkill->MaxLevel)
+        {
+            HudMessage("%d \Cg(-%d)", CheckInventory(AdditionalItem->Actor), AdditionalItemAmount);
+            EndHudMessage(HUDMSG_PLAIN, 0, TextColor, 256.1, 22.0 + YOffset, 0.05);
+        }
+        else
+        {
+            HudMessage("%d", CheckInventory(AdditionalItem->Actor));
+            EndHudMessage(HUDMSG_PLAIN, 0, TextColor, 256.1, 22.0 + YOffset, 0.05);
+        }
     }
 
     // Skill Cost/Next Level Cost
-    PrintSprite("EPUPA0", 0, 248.0, 88.1, 0.05);
+    PrintSprite("EPUPA0", 0, 248.0, 56.1 + YOffset, 0.05);
     SetFont("BIGFONT");
     if (SkillLevel->Level == 0)
     {
         HudMessage("Skill Cost: %d", SkillCostNext);
-        EndHudMessage(HUDMSG_PLAIN, 0, "LightBlue", 256.1, 74.1, 0.05);
+        EndHudMessage(HUDMSG_PLAIN, 0, "LightBlue", 256.1, 42.1 + YOffset, 0.05);
     }
     else if (SkillLevel->Level < CurrentSkill->MaxLevel)
     {
         HudMessage("Skill Cost: %d\nNext Level: %d", SkillCost, SkillCostNext);
-        EndHudMessage(HUDMSG_PLAIN, 0, "LightBlue", 256.1, 74.1, 0.05);
+        EndHudMessage(HUDMSG_PLAIN, 0, "LightBlue", 256.1, 42.1 + YOffset, 0.05);
     }
     else
     {
         HudMessage("Skill Cost: %d", SkillCost);
-        EndHudMessage(HUDMSG_PLAIN, 0, "LightBlue", 256.1, 74.1, 0.05);
+        EndHudMessage(HUDMSG_PLAIN, 0, "LightBlue", 256.1, 42.1 + YOffset, 0.05);
     }
 
     // Skill Cost Multiplier/Refund
     if (Player.SkillCostMult > 0 || Player.SkillRefundMult > 0)
     {
-        PrintSpritePulse("Aura", 0, 232.0, 111.0, 0.75, 64.0, 0.25);
+        PrintSpritePulse("Aura", 0, 232.0, 111.0 + YOffset, 0.75, 32.0, 0.25);
         SetFont("BIGFONT");
         if (Player.SkillRefundMult > 0)
         {
             HudMessage("+%d%% Skill Cost\n%d%% Cost Refund", Player.SkillCostMult, RoundInt(Player.SkillRefundMult * 100));
-            EndHudMessage(HUDMSG_PLAIN, 0, "Cyan", 256.1, 122.0, 0.05);
+            EndHudMessage(HUDMSG_PLAIN, 0, "Cyan", 256.1, 90.0 + YOffset, 0.05);
         }
         else
         {
             HudMessage("+%d%% Skill Cost", Player.SkillCostMult);
-            EndHudMessage(HUDMSG_PLAIN, 0, "Cyan", 256.1, 114.0, 0.05);
+            EndHudMessage(HUDMSG_PLAIN, 0, "Cyan", 256.1, 82.0 + YOffset, 0.05);
         }
     }
 
@@ -1436,10 +1501,10 @@ void DrawSkillMenu()
         for (int i = 0; i < AURA_MAX; i++)
             if (Player.Aura.Type[i].Active)
             {
-                PrintSpritePulse(AuraIcons[i], 0, 232.0 + (i * 24.0), 176.0, 0.75, 64.0, 0.25);
+                PrintSpritePulse(AuraIcons[i], 0, 232.0 + (i * 24.0), 144.0 + YOffset, 0.75, 64.0, 0.25);
                 SetFont("BIGFONT");
                 HudMessage("%d", Player.Aura.Type[i].Level);
-                EndHudMessage(HUDMSG_PLAIN, 0, AuraColors[i], 232.0 + (i * 24.0), 160.0, 0.05);
+                EndHudMessage(HUDMSG_PLAIN, 0, AuraColors[i], 232.0 + (i * 24.0), 128.0 + YOffset, 0.05);
             }
     }
 
@@ -1514,6 +1579,7 @@ void DrawSkillMenu()
         EndHudMessage(HUDMSG_PLAIN, 0, "DarkGray", 0.1, 168.1, 0.05);
     }
 }
+
 void DrawShieldMenu()
 {
     str const PageTitles[4] =
@@ -2637,20 +2703,33 @@ void IncreaseSkill(int Category, int Index)
     SkillLevelInfo *SkillLevel = &Player.SkillLevel[Category][Index];
     int Cost = (int)((((fixed)SkillLevel->Level + 1) * (fixed)MODULE_SKILL_MULT) * GetCVarFixed("drpg_module_skillfactor"));
 
-    if (CheckInventory("DRPGModule") >= Cost)
+    // New
+    ItemInfoPtr  AdditionalItem = GetIncreaseSkillAddItem(Category, Index, SkillLevel->Level);
+    int AdditionalItemAmount = GetIncreaseSkillAddCost(Category, Index, SkillLevel->Level);
+
+    if (SkillLevel->Level < CurrentSkill->MaxLevel)
     {
-        if (SkillLevel->Level < CurrentSkill->MaxLevel && CheckInventory("DRPGModule") >= Cost)
+        if (CheckInventory("DRPGModule") < Cost)
+        {
+            PrintError("You don't have enough Modules");
+            ActivatorSound("menu/error", 127);
+        }
+        else if (AdditionalItemAmount > 0 && CheckInventory(AdditionalItem->Actor) < AdditionalItemAmount)
+        {
+            SetHudSize(0, 0, false);
+            SetFont("BIGFONT");
+            HudMessage("You don't have enough %S", AdditionalItem->Name);
+            EndHudMessage(HUDMSG_FADEOUT, 0, "Red", 0.5, 0.5, 2.0, 1.0);
+            ActivatorSound("menu/error", 127);
+        }
+        else
         {
             SkillLevel->Level++;
             SkillLevel->CurrentLevel++;
             TakeInventory("DRPGModule", Cost);
+            TakeInventory(AdditionalItem->Actor, AdditionalItemAmount);
             ActivatorSound("menu/move", 127);
         }
-    }
-    else
-    {
-        PrintError("You don't have enough Modules");
-        ActivatorSound("menu/error", 127);
     }
 }
 

--- a/DoomRPG/scripts/Outpost.c
+++ b/DoomRPG/scripts/Outpost.c
@@ -3552,8 +3552,8 @@ NamedScript MapSpecial void DisassemblingDevice()
                                 CurrentIndexBasic = -1;
                                 CurrentTypeDetails1 =  12;
                                 CurrentTypeDetails2 =  8;
-                                CurrentAmountDetails1 = 60;
-                                CurrentAmountDetails2 = 40;
+                                CurrentAmountDetails1 = 40;
+                                CurrentAmountDetails2 = 20;
                                 CurrentAmountDetails3 = 20;
                             }
                             // For Plasma Redirection Cannon

--- a/DoomRPG/scripts/Skills.c
+++ b/DoomRPG/scripts/Skills.c
@@ -2330,40 +2330,6 @@ NamedScript Console bool Summon(SkillLevelInfo *SkillLevel, void *Data)
         // Setup Stats
         Delay(4); // We need this initial delay to make sure the ID is valid
         MonsterStatsPtr Stats = &Monsters[GetMonsterID(NewID)];
-
-        if (Player.Augs.Active[AUG_SUMMONER])
-        {
-            fixed AugSummonerModifier;
-
-            if (Player.Augs.CurrentLevel[AUG_SUMMONER] == 5)
-                AugSummonerModifier = 0.10;
-            if (Player.Augs.CurrentLevel[AUG_SUMMONER] == 6)
-                AugSummonerModifier = 0.15;
-            if (Player.Augs.CurrentLevel[AUG_SUMMONER] == 7)
-                AugSummonerModifier = 0.20;
-            if (Player.Augs.CurrentLevel[AUG_SUMMONER] >= 8)
-                AugSummonerModifier = 0.25;
-
-            Stats->LevelAdd += RandomFixed(0.0, (fixed)Stats->Level * (1.0 + AugSummonerModifier) - (fixed)Stats->Level + 0.5);
-
-            if (Player.Augs.CurrentLevel[AUG_SUMMONER] >= 5) Delay (1 * 35);
-
-            fixed BaseStatePoint = (40.0 + 5.0 * (fixed)Stats->Level) / 8.0;
-
-            if (Player.Augs.CurrentLevel[AUG_SUMMONER] >= 1)
-                Stats->Vitality += 20 + RoundInt(BaseStatePoint * ((fixed)Player.EnergyTotal * (0.5 - (fixed)Player.EnergyTotal * 0.0025)) / 100.0);
-            if (Player.Augs.CurrentLevel[AUG_SUMMONER] >= 2)
-                Stats->Defense += 20 + RoundInt(BaseStatePoint * ((fixed)Player.EnergyTotal * (0.5 - (fixed)Player.EnergyTotal * 0.0025)) / 100.0);
-            if (Player.Augs.CurrentLevel[AUG_SUMMONER] >= 3)
-                Stats->Strength += 20 + RoundInt(BaseStatePoint * ((fixed)Player.EnergyTotal * (0.5 - (fixed)Player.EnergyTotal * 0.0025)) / 100.0);
-            if (Player.Augs.CurrentLevel[AUG_SUMMONER] >= 4)
-            {
-                GiveActorInventory(NewID, "DRPGSummonedRegenerationBoosterToken", 1);
-            }
-
-            SetActorInventory(NewID, "DRPGAugTokenSummoner", 1);
-        }
-
         Stats->Threat = CalculateMonsterThreatLevel(&Monsters[GetMonsterID(NewID)]);
         Stats->Flags |= MF_NOXP;
         Stats->Flags |= MF_NODROPS;

--- a/DoomRPG/scripts/inc/Defs.h
+++ b/DoomRPG/scripts/inc/Defs.h
@@ -755,7 +755,7 @@ typedef enum
 #define LUCK_SHIELDINC          0.0005
 #define LUCK_AUGINC             0.00025
 
-#define AURA_CALCTIME           (((GetCVar("drpg_levelup_natural")) ? ((35 * 100) + (35 * Player.EnergyTotal * 2)) : ((35 * 80) + (35 * Player.EnergyTotal * 4))) * (1.0 + Player.AuraBonus * 0.5))
+#define AURA_CALCTIME           (((GetCVar("drpg_levelup_natural")) ? ((35 * 100) + (35 * Player.EnergyTotal * 2)) : ((35 * 80) + (35 * Player.EnergyTotal * 4))) * (long fixed)(1.0 + Player.AuraBonus * 0.5))
 #define DRLA_WEAPON_MAX         (CompatModeEx == COMPAT_DRLAX && PlayerClass(PlayerNumber()) == 9 ? 4 : 6)
 #define DRLA_ARMOR_MAX          2 + ((GetCVar("drpg_levelup_natural")) ? (Player.CapacityTotal / 50) : (Player.CapacityTotal / 25))
 #define DRLA_SKULL_MAX          DRLA_ARMOR_MAX


### PR DESCRIPTION
- rewritten code for AUG Summon. Now it works steadily for all player's summons and subsummons monsters (with some exceptions);
- redesigned Archvile Summoned resurrection - now all resurrected monsters become Player's Summons and get bonuses from "AUG for Summons". All player's summon skills now also work for resurrected monsters. Since they are part of the Summons pool there can also be a limited number of 10 monsters;
- now need a certain amount of Demon Artifacts to learn demon summoning skills;
- other minor fixes.