### PR TITLE
Update 1.31h

### DIFF
--- a/DoomRPG-Doom1/MENUDEF.txt
+++ b/DoomRPG-Doom1/MENUDEF.txt
@@ -1,0 +1,4 @@
+OptionString "OutpostStartLevel"
+{
+    "E1M1",    "E1M1 (Doom)"
+}

--- a/DoomRPG-WadSmoosh/MENUDEF.txt
+++ b/DoomRPG-WadSmoosh/MENUDEF.txt
@@ -18,3 +18,14 @@ OptionMenu "WadSmoosh"
     Option "TNT: Evilution", "drpg_ws_tnt", "OnOff"
     Option "The Plutonia Experiment", "drpg_ws_plut", "OnOff"
 }
+
+OptionString "OutpostStartLevel"
+{
+    "E1M1",    "E1M1 (Doom)"
+    "E5M1",    "E5M1 (Sigil)"
+    "MAP01",   "MAP01 (Doom II)"
+    "NV_MAP01", "NV_MAP01 (No Rest For The Living)"
+    "ML_MAP01", "ML_MAP01 (Master Levels)"
+    "TN_MAP01", "TN_MAP01 (TNT: Evilution)"
+    "PL_MAP01", "PL_MAP01 (The Plutonia Experiment)"
+}

--- a/DoomRPG/GAMEINFO.txt
+++ b/DoomRPG/GAMEINFO.txt
@@ -1,3 +1,3 @@
-startuptitle = "Doom RPG SE Rebalance (2023-04-16)"
+startuptitle = "Doom RPG SE Rebalance (2023-04-23)"
 startupcolors = "0092FF", "000000"
 startuptype = "Hexen"

--- a/DoomRPG/MENUDEF.txt
+++ b/DoomRPG/MENUDEF.txt
@@ -186,12 +186,7 @@ OptionValue "ExtraMapChallenges"
 
 OptionString "OutpostStartLevel"
 {
-    "E1M1",    "E1M1 (Doom)"
-    "E2M1",    "E2M1 (Doom)"
-    "E3M1",    "E3M1 (Doom)"
-    "E4M1",    "E4M1 (Ultimate Doom)"
     "MAP01",   "MAP01 (Doom II)"
-    "LEVEL01", "LEVEL01 (Doom II BFG)"
 }
 
 OptionValue "LootTypes"
@@ -860,6 +855,7 @@ OptionMenu "DoomRPGStart"
     StaticText "Outpost Start", 1
     StaticText "You only need these options set if you"
     StaticText "are starting from the default Outpost."
+	StaticText "Add a Starting Map to the Teleport."
     Option "Starting Map", "drpg_startmap", "OutpostStartLevel"
     Option "Add Starting Map", "drpg_addstartmap", "YesNo"
     StaticText ""

--- a/DoomRPG/scripts/ItemData.c
+++ b/DoomRPG/scripts/ItemData.c
@@ -1365,6 +1365,7 @@ NamedScript DECORATE void DRPGWeaponSpawner(int Weapon)
     int RarityMax;
     int Modifier;
     int Amount;
+    int Penalty;
     int Index;
     int Iterations;
 
@@ -1453,7 +1454,13 @@ NamedScript DECORATE void DRPGWeaponSpawner(int Weapon)
 
                 if (!ItemSpawned && ItemData[ItemCategory][j].Rarity >= RarityMin && ItemData[ItemCategory][j].Rarity <= RarityMax)
                 {
-                    if (Random(0, 100 + (25 * Amount)) <= 50 && Random(0, (ItemData[ItemCategory][j].Spawned * 2) * 100) <= 50)
+                    // Set penalty for an item already spawned
+                    if (ItemData[ItemCategory][j].Spawned < 5)
+                        Penalty = ItemData[ItemCategory][j].Spawned;
+                    else
+                        Penalty = 5;
+
+                    if (Random(0, 100 + (25 * Amount)) <= 50 && Random(0, Penalty * (200 - Penalty * 20)) <= 50)
                     {
                         // Set weapon index
                         Index = j;
@@ -1565,7 +1572,9 @@ NamedScript DECORATE void DRPGWeaponUniqueSpawner()
     int RarityMax = 4;
     int Modifier;
     int Amount;
+    int Penalty;
     int Index;
+    int Iterations;
 
     // Calculate Modifier
     if (GetCVar("drpg_loot_type") == 0)
@@ -1600,7 +1609,13 @@ NamedScript DECORATE void DRPGWeaponUniqueSpawner()
         {
             if (!ItemSpawned && StrMid(ItemData[ItemCategory][i].Name, StrLen(ItemData[ItemCategory][i].Name) - 9, 6) == "Unique" && ItemData[ItemCategory][i].Rarity >= RarityMin && ItemData[ItemCategory][i].Rarity <= RarityMax)
             {
-                if (Random(0, 100 + (25 * Amount)) <= 50 && Random(0, (ItemData[ItemCategory][i].Spawned * 2) * 100) <= 50)
+                // Set penalty for an item already spawned
+                if (ItemData[ItemCategory][i].Spawned < 5)
+                    Penalty = ItemData[ItemCategory][i].Spawned;
+                else
+                    Penalty = 5;
+
+                if (Random(0, 100 + (25 * Amount)) <= 50 && Random(0, Penalty * (200 - Penalty * 20)) <= 50)
                 {
                     // Set weapon index
                     Index = i;
@@ -1636,6 +1651,7 @@ NamedScript DECORATE void DRPGArmorSpawner(int Armor)
     int RarityMax;
     int Modifier;
     int Amount;
+    int Penalty;
     int Index;
     int Iterations;
 
@@ -1742,7 +1758,13 @@ NamedScript DECORATE void DRPGArmorSpawner(int Armor)
 
                 if (!ItemSpawned && ItemData[ItemCategory][j].Rarity >= RarityMin && ItemData[ItemCategory][j].Rarity <= RarityMax)
                 {
-                    if (Random(0, 100 + (25 * Amount)) <= 50 && Random(0, (ItemData[ItemCategory][j].Spawned * 2) * 100) <= 50)
+                    // Set penalty for an item already spawned
+                    if (ItemData[ItemCategory][j].Spawned < 5)
+                        Penalty = ItemData[ItemCategory][j].Spawned;
+                    else
+                        Penalty = 5;
+
+                    if (Random(0, 100 + (25 * Amount)) <= 50 && Random(0, Penalty * (200 - Penalty * 20)) <= 50)
                     {
                         // Set armor index
                         Index = j;
@@ -1862,6 +1884,7 @@ NamedScript DECORATE void DRPGShieldSpawner()
     int RarityMax;
     int Modifier;
     int Amount;
+    int Penalty;
     int Index;
     int Iterations;
     int ShieldPartsMin;
@@ -1919,7 +1942,13 @@ NamedScript DECORATE void DRPGShieldSpawner()
         {
             if (!ItemSpawned && ItemData[ItemCategory][j].Rarity >= RarityMin && ItemData[ItemCategory][j].Rarity <= RarityMax)
             {
-                if (Random(0, 100 + (25 * Amount)) <= 50 && Random(0, (ItemData[ItemCategory][j].Spawned * 2) * 100) <= 50)
+                // Set penalty for an item already spawned
+                if (ItemData[ItemCategory][j].Spawned < 5)
+                    Penalty = ItemData[ItemCategory][j].Spawned;
+                else
+                    Penalty = 5;
+
+                if (Random(0, 100 + (25 * Amount)) <= 50 && Random(0, Penalty * (200 - Penalty * 20)) <= 50)
                 {
                     // Set shield part index
                     Index = j;
@@ -1934,7 +1963,7 @@ NamedScript DECORATE void DRPGShieldSpawner()
         Amount = 0;
         Iterations++;
 
-        if (!ItemSpawned && Iterations >= 9)
+        if (!ItemSpawned && Iterations >= 30)
             switch (Random(0,2))
             {
             case 0:

--- a/DoomRPG/scripts/Map.c
+++ b/DoomRPG/scripts/Map.c
@@ -3845,6 +3845,9 @@ NamedScript void InitMapPacks()
     for (i = 0; i < MAX_MAPPACKS; i++)
     {
         MapPackActive[i] = GetCVar(CvarNames[i]); //find which iwads user says they have
+
+        if (GetCVar("drpg_addstartmap") && LumpNames[i] == GetCVarString("drpg_startmap"))
+            MapPackActive[i] = true; //activate the iwad if it is a starter map
     };
 
     bool StartedOnMap = KnownLevels->Position > 1;

--- a/DoomRPG/scripts/RPG.c
+++ b/DoomRPG/scripts/RPG.c
@@ -2465,6 +2465,10 @@ void CheckCompatibility()
 
     MapPacks = false;
 
+    // Starting Map
+    if (!InTitle && CurrentLevel->UACBase && GetCVar("drpg_addstartmap"))
+        MapPacks = true;
+
     // WadSmoosh
     Success = SpawnForced("DRPGWadSmooshActive", 0, 0, 0, TID, 0);
     if (Success)

--- a/README.md
+++ b/README.md
@@ -54,3 +54,12 @@ Use the following load order:
 - [Dehacked Attack v4.0](https://forum.zdoom.org/viewtopic.php?f=43&t=72362);
 - [Pandemonia Monsters v2.2](https://forum.zdoom.org/viewtopic.php?t=60984);
 - Custom version of Jimmy's Jukebox Instant Randomizer has been included which allows DRPG's map events and Outpost music to play.
+
+## Donate
+
+If you want to help this project:
+
+BTC: bc1qenxqtz0rn2tpeczg9dtqy0j7vlaew2a3cg392v
+ETH: 0x3aBee6C1dAD4C2f9c419c88bcab0F63B8dD802BE
+LTC: ltc1q0gj547xe9ltpd5dfxvdw8gvha85n2sqmrv07h8
+DOGE: DJQMZyphTkUhtyJ4DDHjskaphCfDZusu5b


### PR DESCRIPTION
- fix: "runaway script, drpgweaponspawner terminated" could appear in the late stages of the game;
- fix: "Starting map does not work." #400. This option now adds a start map to the teleporter when needed. For example, when you use Lexicon and/or Obsidian, you can add MAP01 to the teleporter and use that.