### PR TITLE
Addition of option to disable (most) DRPG related screen flashes.

### DIFF
--- a/DoomRPG/CVARINFO.txt
+++ b/DoomRPG/CVARINFO.txt
@@ -279,6 +279,7 @@ user    bool    drpg_shield_sound_empty_enable = true;
 user    bool    drpg_shield_sound_charge_enable = true;
 user    bool    drpg_shield_sound_full_enable = true;
 user    bool    drpg_shield_effect_hit_enable = true;
+user	bool	drpg_screen_flash_disable = false;
 server  int     drpg_ws_use_wads = 1;
 
 // Performance

--- a/DoomRPG/MENUDEF.txt
+++ b/DoomRPG/MENUDEF.txt
@@ -804,6 +804,8 @@ OptionMenu "DoomRPGMisc"
     Option "Sound Full Energy Shield", "drpg_shield_sound_full_enable", "OnOff"
     Option "Sound and Effect of Hitting Energy Shield", "drpg_shield_effect_hit_enable", "OnOff"
     StaticText ""
+	Option "Disable DRPG related screen flashes", "drpg_screen_flash_disable", "OnOff"
+	StaticText ""
 
     StaticText "Quality loot items, armor, weapons and monster spawns depend on the number of WADs passed."
     StaticText "Lower number of WADs that you plan to go through to increase the intensity."

--- a/DoomRPG/scripts/Map.c
+++ b/DoomRPG/scripts/Map.c
@@ -535,7 +535,7 @@ Start:
             if (!PlayerInGame(i))
                 continue;
 
-            FadeRange(255, 255, 0, 0.25, 255, 255, 0, 0, 1.0);
+            FadeRangeFlash(255, 255, 0, 0.25, 255, 255, 0, 0, 1.0);
 
             RankBonus = (((long int)(RankTable[Players(i).RankLevel]) / (long)(100 + RoundInt(100.0 * (Player.RankLevel / 24.0)))) + 250l) / 250l * 250l;
             Players(i).Rank += RankBonus;
@@ -578,7 +578,7 @@ Start:
 
             SetActivator(Players(i).TID);
 
-            FadeRange(255, 0, 0, 0.25, 255, 0, 0, 0, 1.0);
+            FadeRangeFlash(255, 0, 0, 0.25, 255, 0, 0, 0, 1.0);
 
             if (Players(i).Level < MAX_LEVEL)
             {
@@ -612,7 +612,7 @@ Start:
 
             SetActivator(Players(i).TID);
 
-            FadeRange(0, 255, 255, 0.25, 0, 255, 255, 0, 1.0);
+            FadeRangeFlash(0, 255, 255, 0.25, 0, 255, 255, 0, 1.0);
 
             HealThing(MAX_HEALTH);
             Players(i).EP = Players(i).EPMax;
@@ -635,7 +635,7 @@ Start:
 
             SetActivator(Players(i).TID);
 
-            FadeRange(255, 255, 0, 0.25, 255, 255, 0, 0, 1.0);
+            FadeRangeFlash(255, 255, 0, 0.25, 255, 255, 0, 0, 1.0);
 
             if (Players(i).RankLevel < MAX_RANK)
             {
@@ -669,7 +669,7 @@ Start:
 
             SetActivator(Players(i).TID);
 
-            FadeRange(255, 255, 255, 0.25, 255, 255, 255, 0, 1.0);
+            FadeRangeFlash(255, 255, 255, 0.25, 255, 255, 255, 0, 1.0);
 
             HealThing(MAX_HEALTH);
             Players(i).EP = Players(i).EPMax;
@@ -913,7 +913,7 @@ NumberedScript(MAP_EXIT_SCRIPTNUM) MapSpecial void MapExit(bool Secret, bool Tel
             SetActivator(Players(i).TID);
 
             SetFont("SMALLFONT");
-            FadeRange(255, 255, 0, 0.25, 255, 255, 0, 0.0, 1.0);
+            FadeRangeFlash(255, 255, 0, 0.25, 255, 255, 0, 0.0, 1.0);
 
             if (Players(i).RankLevel < MAX_RANK)
             {
@@ -2803,7 +2803,7 @@ NamedScript void DoomsdayEvent()
             continue;
 
         SetActorProperty(Players(i).TID, APROP_Health, -1000000);
-        FadeRange(255, 255, 255, 1.0, 255, 255, 255, 0.0, 2.0);
+        FadeRangeFlash(255, 255, 255, 1.0, 255, 255, 255, 0.0, 2.0);
         ActivatorSound("nuke/detonate", 127);
         Radius_Quake2(0, 9, 70, 0, 512, "None");
     }
@@ -2827,7 +2827,7 @@ NamedScript void DoomsdayFirebomb(int PlayerTID)
         Delay(Random(35 * 30, 35 * 90));
         SpawnSpotFacing("DRPGDoomsdayMortarBlast", 0, 0);
         Radius_Quake2(0, 6, 16, 0, 512, "None");
-        FadeRange(255, 128, 64, 0.33, 255, 128, 64, 0.0, 0.5);
+        FadeRangeFlash(255, 128, 64, 0.33, 255, 128, 64, 0.0, 0.5);
         ActivatorSound("drpgmarines/bulletexp", 127);
         if (CurrentLevel->DoomTime < (GetLevelInfo(LEVELINFO_PAR_TIME) ? GetLevelInfo(LEVELINFO_PAR_TIME) * 2 : GetCVar("drpg_default_par_seconds") * 2))
         {

--- a/DoomRPG/scripts/Menu.c
+++ b/DoomRPG/scripts/Menu.c
@@ -2820,7 +2820,7 @@ void IncreaseSkill(int Category, int Index, bool UsingOverdrive)
                 ActivatorSound("menu/move", 127);
             else
             {
-                FadeRange(0, 255, 255, 0.5, 0, 255, 255, 0.0, 0.5);
+                FadeRangeFlash(0, 255, 255, 0.5, 0, 255, 255, 0.0, 0.5);
                 ActivatorSound("health/epcapsule", 127);
             }
         }

--- a/DoomRPG/scripts/Monsters.c
+++ b/DoomRPG/scripts/Monsters.c
@@ -2316,7 +2316,7 @@ Start:
                 int NewTID = UniqueTID(0, 0);
                 Thing_ChangeTID(0, NewTID);
                 SetActivator(Players(i).TID);
-                FadeRange(64, 128, 128, 0.5, 64, 128, 128, 0.0, 0.5);
+                FadeRangeFlash(64, 128, 128, 0.5, 64, 128, 128, 0.0, 0.5);
                 ActivatorSound("drain/ep", 32);
                 SetActivator(NewTID);
                 Thing_ChangeTID(0, OrigTID);
@@ -2480,7 +2480,7 @@ Start:
                 int NewTID = UniqueTID(0, 0);
                 Thing_ChangeTID(0, NewTID);
                 SetActivator(Players(i).TID);
-                FadeRange(255, 0, 0, 0.5, 255, 0, 0, 0.0, 0.5);
+                FadeRangeFlash(255, 0, 0, 0.5, 255, 0, 0, 0.0, 0.5);
                 TryStatusEffect(SE_CURSE, Random(30, 90), Intensity);
                 SetActivator(NewTID);
                 Thing_ChangeTID(0, OrigTID);
@@ -2508,7 +2508,7 @@ Start:
                 int NewTID = UniqueTID(0, 0);
                 Thing_ChangeTID(0, NewTID);
                 SetActivator(Players(i).TID);
-                FadeRange(255, 0, 0, 0.5, 255, 0, 0, 0.0, 0.5);
+                FadeRangeFlash(255, 0, 0, 0.5, 255, 0, 0, 0.0, 0.5);
                 TryStatusEffect(SE_SILENCE, Random(30, 90), Intensity);
                 SetActivator(NewTID);
                 Thing_ChangeTID(0, OrigTID);
@@ -2576,7 +2576,7 @@ Start:
             TakeActorInventory(Players(i).TID, "DRPGCredits", (int)(Stats->Luck * GetCVarFixed("drpg_aurasteal_amount")));
             GiveInventory("DRPGCredits", (int)(Stats->Luck * GetCVarFixed("drpg_aurasteal_amount")));
             SetActivator(Players(i).TID);
-            FadeRange(255, 255, 0, 0.5, 255, 255, 0, 0.0, 0.5);
+            FadeRangeFlash(255, 255, 0, 0.5, 255, 255, 0, 0.0, 0.5);
             ActivatorSound("drain/money", 32);
             SetActivator(NewTID);
             Thing_ChangeTID(0, OrigTID);
@@ -2671,7 +2671,7 @@ Start:
             int NewTID = UniqueTID(0, 0);
             Thing_ChangeTID(0, NewTID);
             SetActivator(Players(i).TID);
-            FadeRange(0, 0, 255, 0.5, 0, 0, 255, 0.0, 0.5);
+            FadeRangeFlash(0, 0, 255, 0.5, 0, 0, 255, 0.0, 0.5);
             ActivatorSound("drain/ammo", 32);
             SetActivator(NewTID);
             Thing_ChangeTID(0, OrigTID);

--- a/DoomRPG/scripts/Outpost.c
+++ b/DoomRPG/scripts/Outpost.c
@@ -181,7 +181,7 @@ NamedScript MapSpecial void RegenArea(int ID)
             SetFont("BIGFONT");
             HudMessage("Health restored");
             EndHudMessage(HUDMSG_FADEOUT, 0, "Brick", 0.5, 0.33, 2.0, 0.5);
-            FadeRange(255, 0, 0, 0.5, 255, 0, 0, 0.0, 1.0);
+            FadeRangeFlash(255, 0, 0, 0.5, 255, 0, 0, 0.0, 1.0);
             ActivatorSound("regen/health", 127);
         }
     }
@@ -224,7 +224,7 @@ NamedScript MapSpecial void RegenArea(int ID)
         SetFont("BIGFONT");
         HudMessage("Armor repaired");
         EndHudMessage(HUDMSG_FADEOUT, 0, "Green", 0.5, 0.33, 2.0, 0.5);
-        FadeRange(0, 255, 0, 0.5, 0, 255, 0, 0.0, 1.0);
+        FadeRangeFlash(0, 255, 0, 0.5, 0, 255, 0, 0.0, 1.0);
         ActivatorSound("regen/armor", 127);
     }
 
@@ -254,7 +254,7 @@ NamedScript MapSpecial void RegenArea(int ID)
             SetFont("BIGFONT");
             HudMessage("Shield restored");
             EndHudMessage(HUDMSG_FADEOUT, 0, "Cyan", 0.5, 0.33, 2.0, 0.5);
-            FadeRange(0, 255, 255, 0.5, 0, 255, 255, 0.0, 1.0);
+            FadeRangeFlash(0, 255, 255, 0.5, 0, 255, 255, 0.0, 1.0);
             ActivatorSound("regen/shield", 127);
         }
         else
@@ -304,7 +304,7 @@ NamedScript MapSpecial void RegenArea(int ID)
             SetFont("BIGFONT");
             HudMessage("EP restored");
             EndHudMessage(HUDMSG_FADEOUT, 0, "LightBlue", 0.5, 0.33, 2.0, 0.5);
-            FadeRange(0, 255, 255, 0.5, 0, 255, 255, 0.0, 1.0);
+            FadeRangeFlash(0, 255, 255, 0.5, 0, 255, 255, 0.0, 1.0);
             ActivatorSound("regen/ep", 127);
         }
     }
@@ -327,7 +327,7 @@ NamedScript MapSpecial void RegenArea(int ID)
         SetFont("BIGFONT");
         HudMessage("Augmentation battery recharged");
         EndHudMessage(HUDMSG_FADEOUT, 0, "Yellow", 0.5, 0.33, 2.0, 0.5);
-        FadeRange(255, 255, 0, 0.5, 255, 255, 0, 0.0, 1.0);
+        FadeRangeFlash(255, 255, 0, 0.5, 255, 255, 0, 0.0, 1.0);
         ActivatorSound("regen/battery", 127);
     }
 }

--- a/DoomRPG/scripts/Shield.c
+++ b/DoomRPG/scripts/Shield.c
@@ -682,7 +682,7 @@ NamedScript bool CellFastCharge()
     if (CheckInventory("Cell") < 1) return true;
 
     TakeInventory("Cell", 1);
-    FadeRange(0, 255, 255, 0.1, 0, 255, 255, 0.0, 0.5);
+    FadeRangeFlash(0, 255, 255, 0.1, 0, 255, 255, 0.0, 0.5);
     ActivatorSound("regen/shield", 64);
     AddShield(10);
 
@@ -773,7 +773,7 @@ NamedScript void TeleportBreak()
 {
     if (Player.Shield.AccessoryBattery)
     {
-        FadeRange(118, 255, 112, 0.5, 118, 255, 112, 0, 1.0);
+        FadeRangeFlash(118, 255, 112, 0.5, 118, 255, 112, 0, 1.0);
         SetActorPosition(0, Player.Shield.AccessoryPosition.X, Player.Shield.AccessoryPosition.Y, Player.Shield.AccessoryPosition.Z, true);
         SetActorAngle(0, Player.Shield.AccessoryPosition.Angle);
         SetActorPitch(0, Player.Shield.AccessoryPosition.Pitch);
@@ -832,7 +832,7 @@ NamedScript void FlanExplosion() // This gets called on full charge too
             GiveActorInventory(Players(i).Turret.TID, "DRPGShieldRadialExplosionResist", 1);
     }
 
-    FadeRange(255, 128, 0, 0.5, 255, 128, 0, 0.0, 0.5);
+    FadeRangeFlash(255, 128, 0, 0.5, 255, 128, 0, 0.0, 0.5);
     GiveInventory("DRPGShieldRadialExplosionMaker", 1);
     SayItOhYeahOhBaby();
 
@@ -846,7 +846,7 @@ NamedScript void SpaghettiShieldBreak()
     if (CheckInventory("Armor") == 0 || CheckInventory("Armor") >= GetArmorInfo(ARMORINFO_SAVEAMOUNT) || !Player.Shield.AccessoryBattery)
         return;
 
-    FadeRange(0, 255, 0, 0.5, 0, 255, 0, 0, 1.0);
+    FadeRangeFlash(0, 255, 0, 0.5, 0, 255, 0, 0, 1.0);
     GiveInventory(GetArmorInfoString(ARMORINFO_CLASSNAME), 1);
     ActivatorSound("skills/repair", 127);
     Player.Shield.AccessoryBattery = 0;
@@ -891,7 +891,7 @@ NamedScript void AmpShieldMod()
             if (CheckInput(BT_ATTACK, KEY_HELD, false, PlayerNumber()) && !Player.InMenu && !Player.InShop && !Player.OutpostMenu)
             {
                 PlaySound(0, "shield/amp", 5, 1.0, false, 1.0);
-                FadeRange(255, 255, 255, 0.25, 255, 255, 255, 0.0, 0.5);
+                FadeRangeFlash(255, 255, 255, 0.25, 255, 255, 255, 0.0, 0.5);
                 Player.Shield.Charge /= 2;
                 Player.Shield.AccessoryBattery = 70;
             }
@@ -1147,7 +1147,7 @@ NamedScript void OhYeahMod()
                 GiveActorInventory(Players(i).Turret.TID, "DRPGShieldRadialExplosionResist", 1);
         }
 
-        FadeRange(255, 128, 0, 0.5, 255, 128, 0, 0.0, 0.5);
+        FadeRangeFlash(255, 128, 0, 0.5, 255, 128, 0, 0.0, 0.5);
         GiveInventory("DRPGShieldRadialExplosionMaker", 1);
         SayItOhYeahOhBaby();
     }
@@ -1333,7 +1333,7 @@ NamedScript bool ActivateShield()
         return false;
     }
 
-    FadeRange(255, 255, 255, 0.25, 255, 255, 255, 0.0, 0.25);
+    FadeRangeFlash(255, 255, 255, 0.25, 255, 255, 255, 0.0, 0.25);
 
     if (Player.Shield.Accessory && Player.Shield.Accessory->Equip)
         Player.Shield.Accessory->Equip();
@@ -1351,7 +1351,7 @@ NamedScript bool DeactivateShield()
     if (!Player.Shield.Active)
         return true;
 
-    FadeRange(255, 255, 255, 0.25, 255, 255, 255, 0.0, 0.25);
+    FadeRangeFlash(255, 255, 255, 0.25, 255, 255, 255, 0.0, 0.25);
 
     if (Player.Shield.Accessory && Player.Shield.Accessory->Unequip)
         Player.Shield.Accessory->Unequip(Player.StatusType[SE_EMP]);
@@ -1407,7 +1407,7 @@ NamedScript DECORATE void AddShield(int Amount)
         else
             PlaySound(0, "shield/charge", 5, 0.25, false, 2.0);
     };
-    FadeRange(0, 255, 255, 0.25, 0, 255, 255, 0, 0.25);
+    FadeRangeFlash(0, 255, 255, 0.25, 0, 255, 255, 0, 0.25);
     if (Player.Shield.Charge + Amount > Player.Shield.Capacity)
         Amount = Player.Shield.Capacity - Player.Shield.Charge;
 
@@ -1443,7 +1443,7 @@ void CheckShields()
 
         if (!SkipEPCharge && Player.EP > 0)
         {
-            FadeRange(0, 255, 255, 0.1, 0, 255, 255, 0.0, 0.5);
+            FadeRangeFlash(0, 255, 255, 0.1, 0, 255, 255, 0.0, 0.5);
             ActivatorSound("regen/shield", 64);
             Player.EP--;
             Player.Shield.Charge++;

--- a/DoomRPG/scripts/Skills.c
+++ b/DoomRPG/scripts/Skills.c
@@ -1095,7 +1095,7 @@ NamedScript Console bool Heal(SkillLevelInfo *SkillLevel, void *Data)
 
             SetActivator(Players(i).TID);
 
-            FadeRange(255, 0, 255, 0.5, 255, 0, 255, 0, 1.0);
+            FadeRangeFlash(255, 0, 255, 0.5, 255, 0, 255, 0, 1.0);
             ActivatorSound("skills/heal", (Players(i).TID == PlayerTID ? 127 : 64));
         }
 
@@ -1103,7 +1103,7 @@ NamedScript Console bool Heal(SkillLevelInfo *SkillLevel, void *Data)
     }
     else
     {
-        FadeRange(255, 0, 255, 0.5, 255, 0, 255, 0, 1.0);
+        FadeRangeFlash(255, 0, 255, 0.5, 255, 0, 255, 0, 1.0);
         ActivatorSound("skills/heal", 127);
     }
 
@@ -1120,7 +1120,7 @@ NamedScript Console bool HealSummons(SkillLevelInfo *SkillLevel, void *Data)
         return false;
     }
 
-    FadeRange(255, 0, 255, 0.5, 255, 0, 255, 0, 1.0);
+    FadeRangeFlash(255, 0, 255, 0.5, 255, 0, 255, 0, 1.0);
 
     for (int i = 0; i < MAX_SUMMONS; i++)
         if (Player.SummonTID[i] > 0)
@@ -1147,7 +1147,7 @@ NamedScript Console bool Decontaminate(SkillLevelInfo *SkillLevel, void *Data)
     ClearToxicityMeter();
 
     ActivatorSound("skills/decontaminate", 127);
-    FadeRange(0, 255, 0, 0.5, 0, 255, 0, 0.0, 1.0);
+    FadeRangeFlash(0, 255, 0, 0.5, 0, 255, 0, 0.0, 1.0);
 
     Player.SkillCostMult += 25;
 
@@ -1173,7 +1173,7 @@ NamedScript Console bool Repair(SkillLevelInfo *SkillLevel, void *Data)
         }
     }
 
-    FadeRange(0, 255, 0, 0.5, 0, 255, 0, 0, 1.0);
+    FadeRangeFlash(0, 255, 0, 0.5, 0, 255, 0, 0, 1.0);
     GiveInventory(GetArmorInfoString(ARMORINFO_CLASSNAME), 1);
 
     ActivatorSound("skills/repair", 127);
@@ -1548,7 +1548,7 @@ NamedScript Console bool Weaken(SkillLevelInfo *SkillLevel, void *Data)
     // Reset Activator
     SetActivator(Players(PlayerNum).TID);
 
-    FadeRange(0, 0, 0, 0.25, 0, 0, 0, 0.0, 1.0);
+    FadeRangeFlash(0, 0, 0, 0.25, 0, 0, 0, 0.0, 1.0);
     ActivatorSound("skills/weaken", 127);
     return true;
 }
@@ -1571,7 +1571,7 @@ NamedScript Console bool Repulse(SkillLevelInfo *SkillLevel, void *Data)
     SetInventory(StrParam("DRPGSkillBlast%d", SkillLevel->CurrentLevel), 1);
     UseInventory(StrParam("DRPGSkillBlast%d", SkillLevel->CurrentLevel));
 
-    FadeRange(255, 255, 0, 0.1, 255, 255, 0, 0.0, 0.5 + (0.25 * SkillLevel->CurrentLevel));
+    FadeRangeFlash(255, 255, 0, 0.1, 255, 255, 0, 0.0, 0.5 + (0.25 * SkillLevel->CurrentLevel));
 
     return true;
 }
@@ -1770,7 +1770,7 @@ NamedScript Console bool SoulSteal(SkillLevelInfo *SkillLevel, void *Data)
     // Heal the user
     AddHealthDirect(LeechAmount, 100);
 
-    FadeRange(0, 0, 0, 0.5, 0, 0, 0, 0.0, 0.25);
+    FadeRangeFlash(0, 0, 0, 0.5, 0, 0, 0, 0.0, 0.25);
     ActivatorSound("skills/soulsteal", 127);
     return true;
 }
@@ -1791,7 +1791,7 @@ NamedScript Console bool Disruption(SkillLevelInfo *SkillLevel, void *Data)
         else
             GiveInventory("DRPGAreaDisruptionSmall", 1);
 
-        FadeRange(0, 64, 255, 0.5, 0, 64, 255, 0.0, 0.25);
+        FadeRangeFlash(0, 64, 255, 0.5, 0, 64, 255, 0.0, 0.25);
         ActivatorSound("skills/disruption", 127);
 
         return true;
@@ -1871,7 +1871,7 @@ NamedScript Console bool Disruption(SkillLevelInfo *SkillLevel, void *Data)
     // Reset the temporary TID
     Thing_ChangeTID(UniqueMonsterTID, RealMonsterTID);
 
-    FadeRange(0, 64, 255, 0.5, 0, 64, 255, 0.0, 0.25);
+    FadeRangeFlash(0, 64, 255, 0.5, 0, 64, 255, 0.0, 0.25);
     ActivatorSound("skills/disruption", 127);
     return true;
 }
@@ -2483,7 +2483,7 @@ NamedScript Console bool Unsummon(SkillLevelInfo *SkillLevel, void *Data)
 
         Player.Familiars = false;
 
-        FadeRange(192, 0, 0, 0.5, 192, 0, 0, 0.0, 1.0);
+        FadeRangeFlash(192, 0, 0, 0.5, 192, 0, 0, 0.0, 1.0);
         ActivatorSound("skills/unsummon", 127);
         return true;
     }
@@ -2525,7 +2525,7 @@ NamedScript Console bool Unsummon(SkillLevelInfo *SkillLevel, void *Data)
 
     Player.Summons = 0;
 
-    FadeRange(192, 0, 0, 0.5, 192, 0, 0, 0.0, 1.0);
+    FadeRangeFlash(192, 0, 0, 0.5, 192, 0, 0, 0.0, 1.0);
     ActivatorSound("skills/unsummon", 127);
     return true;
 }
@@ -2794,7 +2794,7 @@ NamedScript Console bool Magnetize(SkillLevelInfo *SkillLevel, void *Data)
             Angle += AngleAdd;
         }
     }
-    FadeRange(0, 0, 0, 0.5, 0, 0, 0, 0.0, 1.0);
+    FadeRangeFlash(0, 0, 0, 0.5, 0, 0, 0, 0.0, 1.0);
     ActivatorSound("skills/magnet", 127);
     return true;
 }

--- a/DoomRPG/scripts/Stats.c
+++ b/DoomRPG/scripts/Stats.c
@@ -314,7 +314,7 @@ void CheckLevel()
                 Player.EP = Player.EPMax;
             }
 
-            FadeRange(255, 255, 255, 0.5, 255, 255, 255, 0, 2.0);
+            FadeRangeFlash(255, 255, 255, 0.5, 255, 255, 255, 0, 2.0);
 
             if (GetActivatorCVar("drpg_notifications_detailed"))
                 HudMessage("You have reached level %d", Player.Level);
@@ -416,7 +416,7 @@ void CheckRank()
             // Take negative Rank
             Player.Rank = RankTable[Player.RankLevel] + Player.Rank;
 
-            FadeRange(255, 0, 64, 0.25, 255, 0, 64, 0, 2.0);
+            FadeRangeFlash(255, 0, 64, 0.25, 255, 0, 64, 0, 2.0);
 
             if (GetActivatorCVar("drpg_notifications_detailed"))
                 HudMessage("\CaYou have been demoted to rank %d: %S", Player.RankLevel, LongRanks[Player.RankLevel]);
@@ -440,7 +440,7 @@ void CheckRank()
             Player.RankLevel++;
 
             ActivatorSound("misc/rankup", 96);
-            FadeRange(255, 255, 0, 0.5, 255, 255, 0, 0, 2.0);
+            FadeRangeFlash(255, 255, 0, 0.5, 255, 255, 0, 0, 2.0);
 
             // Determine how many new items you've unlocked in the shop
             for (int i = 0; i < ItemCategories; i++)
@@ -486,7 +486,7 @@ void CheckHealth()
     if (Player.ActualHealth <= Player.HealthMax / 10 && !Player.Perks[STAT_VITALITY])
     {
         // Fade Effect
-        FadeRange(255, 0, 0, 0.15 + (Sin(Timer() / 64.0) * 0.1), 255, 0, 0, 0.0, 1.0);
+        FadeRangeFlash(255, 0, 0, 0.15 + (Sin(Timer() / 64.0) * 0.1), 255, 0, 0, 0.0, 1.0);
 
         // Heartbeat
         if ((Timer() % 64) == 0 && Player.ActualHealth > 0)
@@ -1077,7 +1077,7 @@ void CheckBurnout()
         if (Intensity > 0.25) Intensity = 0.25;
 
         // Screen Effect
-        FadeRange(0, 128, 255, Intensity + (Sin(Timer() / 256.0) * 0.1), 0, 128, 255, 0, 0.25);
+        FadeRangeFlash(0, 128, 255, Intensity + (Sin(Timer() / 256.0) * 0.1), 0, 128, 255, 0, 0.25);
 
         // Penalties
         Player.TotalDamage /= 2;
@@ -1243,7 +1243,7 @@ void ToxicityDamage()
 void CheckStatusEffects()
 {
     if (Player.StatusType[SE_BLIND]) // Blind
-        FadeRange(0, 0, 0, (0.5 + (Player.StatusIntensity[SE_BLIND] * 0.1)) - (Sin(Timer() / 128.0) * 0.25), 0, 0, 0, 0.0, 0.5);
+        FadeRangeFlash(0, 0, 0, (0.5 + (Player.StatusIntensity[SE_BLIND] * 0.1)) - (Sin(Timer() / 128.0) * 0.25), 0, 0, 0, 0.0, 0.5);
 
     if (Player.StatusType[SE_CONFUSION]) // Confusion
     {
@@ -1280,7 +1280,7 @@ void CheckStatusEffects()
             if (Player.ActualHealth - Player.StatusIntensity[SE_POISON] > 0)
             {
                 Player.ActualHealth -= Player.StatusIntensity[SE_POISON];
-                FadeRange(0, 255, 0, 0.25, 0, 255, 0, 0.0, Player.StatusIntensity[SE_POISON] * 0.25);
+                FadeRangeFlash(0, 255, 0, 0.25, 0, 255, 0, 0.0, Player.StatusIntensity[SE_POISON] * 0.25);
             }
 
     if (Player.StatusType[SE_CORROSION]) // Corrosion
@@ -1288,7 +1288,7 @@ void CheckStatusEffects()
             if (CheckInventory("Armor") - Player.StatusIntensity[SE_CORROSION] > 0)
             {
                 TakeInventory("BasicArmor", Player.StatusIntensity[SE_CORROSION]);
-                FadeRange(0, 255, 0, 0.25, 0, 255, 0, 0.0, Player.StatusIntensity[SE_CORROSION] * 0.25);
+                FadeRangeFlash(0, 255, 0, 0.25, 0, 255, 0, 0.0, Player.StatusIntensity[SE_CORROSION] * 0.25);
             }
 
     if (Player.StatusType[SE_VIRUS]) // Virus
@@ -1332,7 +1332,7 @@ void CheckStatusEffects()
                 if (Player.Toxicity + i > 85)
                     i = 85 - Player.Toxicity;
                 AddToxicity(i);
-                FadeRange(0, 255, 0, 0.25, 0, 255, 0, 0.0, i * 0.25);
+                FadeRangeFlash(0, 255, 0, 0.25, 0, 255, 0, 0.0, i * 0.25);
             }
         }
 

--- a/DoomRPG/scripts/Stims.c
+++ b/DoomRPG/scripts/Stims.c
@@ -165,7 +165,7 @@ NamedScript KeyBind void UseStim(bool Force)
     ActivatorSound("items/stim", 127);
     if (Random(0, 100) == 0) // DRUGS
         ActivatorSound("misc/drugs", 127);
-    FadeRange(255, 255, 255, 0.25, 255, 255, 255, 0, 1.0);
+    FadeRangeFlash(255, 255, 255, 0.25, 255, 255, 255, 0, 1.0);
 }
 
 NamedScript KeyBind void ThrowAwayStim()

--- a/DoomRPG/scripts/Utils.c
+++ b/DoomRPG/scripts/Utils.c
@@ -921,7 +921,7 @@ NamedScript KeyBind void SetSkill(int NewSkill)
         return;
     }
 
-    FadeRange(255, 255, 255, 0.5, 255, 255, 255, 0.0, 0.5);
+    FadeRangeFlash(255, 255, 255, 0.5, 255, 255, 255, 0.0, 0.5);
     ChangeSkill(NewSkill);
     CurrentSkill = NewSkill;
     ActivatorSound("misc/skillchange", 127);
@@ -1030,7 +1030,7 @@ NamedScript KeyBind void Respec(bool DoStats, bool DoSkills)
     TakeInventory("DRPGCredits", Player.Level * 750);
 
     // FX
-    FadeRange(255, 255, 255, 0.75, 0, 0, 0, 0.0, 2.5);
+    FadeRangeFlash(255, 255, 255, 0.75, 0, 0, 0, 0.0, 2.5);
     SetFont("BIGFONT");
     HudMessage("Respec Complete");
     EndHudMessage(HUDMSG_FADEOUT, 0, "White", 0.5, 0.5, 2.5, 2.5);
@@ -1597,7 +1597,7 @@ NamedScript DECORATE void AddEP(int Amount, bool NoFlash)
         FlashDuration = 3.0;
 
     if (!NoFlash)
-        FadeRange(0, 255, 255, FlashStrength, 0, 255, 255, 0, FlashDuration);
+        FadeRangeFlash(0, 255, 255, FlashStrength, 0, 255, 255, 0, FlashDuration);
 
     Player.EP += Amount;
 }
@@ -2051,6 +2051,16 @@ str PlayerName(int n)
     return EndStrParam();
 }
 
+// [YuNoGuy123]: For flashing screen effects, we use this to check if we should actually flash or not. Is this okay to do? I'm unsure...
+NamedScript void FadeRangeFlash(int red1, int green1, int blue1, fixed amount1, int red2, int green2, int blue2, fixed amount2, fixed seconds)
+{
+    if (!GetCVar("drpg_screen_flash_disable"))
+    {
+        FadeRange(red1, green1, blue1, amount1, red2, green2, blue2, amount2, seconds);
+    }
+
+}
+
 NamedScript void PrintTextWiggle(char *Text, int ID, int Color, int X, int Y, fixed HoldTime, fixed Speed, fixed Spacing, fixed Radius)
 {
     int Time = (int)(HoldTime * 35.0);
@@ -2109,28 +2119,28 @@ NamedScript void DrawStatUp(int Stat)
     switch (Stat)
     {
     case STAT_STRENGTH:
-        FadeRange(255, 0, 0, 0.25, 255, 0, 0, 0.0, 0.5);
+        FadeRangeFlash(255, 0, 0, 0.25, 255, 0, 0, 0.0, 0.5);
         break;
     case STAT_DEFENSE:
-        FadeRange(0, 255, 0, 0.25, 0, 255, 0, 0.0, 0.5);
+        FadeRangeFlash(0, 255, 0, 0.25, 0, 255, 0, 0.0, 0.5);
         break;
     case STAT_VITALITY:
-        FadeRange(255, 0, 255, 0.25, 255, 0, 255, 0.0, 0.5);
+        FadeRangeFlash(255, 0, 255, 0.25, 255, 0, 255, 0.0, 0.5);
         break;
     case STAT_ENERGY:
-        FadeRange(0, 255, 255, 0.25, 0, 255, 255, 0.0, 0.5);
+        FadeRangeFlash(0, 255, 255, 0.25, 0, 255, 255, 0.0, 0.5);
         break;
     case STAT_REGENERATION:
-        FadeRange(128, 0, 128, 0.25, 128, 0, 128, 0.0, 0.5);
+        FadeRangeFlash(128, 0, 128, 0.25, 128, 0, 128, 0.0, 0.5);
         break;
     case STAT_AGILITY:
-        FadeRange(255, 128, 0, 0.25, 255, 128, 0, 0.0, 0.5);
+        FadeRangeFlash(255, 128, 0, 0.25, 255, 128, 0, 0.0, 0.5);
         break;
     case STAT_CAPACITY:
-        FadeRange(0, 0, 255, 0.25, 0, 0, 255, 0.0, 0.5);
+        FadeRangeFlash(0, 0, 255, 0.25, 0, 0, 255, 0.0, 0.5);
         break;
     case STAT_LUCK:
-        FadeRange(255, 255, 0, 0.25, 255, 255, 0, 0.0, 0.5);
+        FadeRangeFlash(255, 255, 0, 0.25, 255, 255, 0, 0.0, 0.5);
         break;
     }
 


### PR DESCRIPTION
As per issue #415 screen flashing can be a problem at times, I've seen it mentioned a few times elsewhere as well, so I decided to add a sort of option for it.

This option, titled "Disable DRPG related screen flashes" will disable most uses of screen flashing in DRPG (outside of a few cases where other options cover the flashes)