### PR TITLE
Uodate 1.33 hotfix 1

### DIFF
--- a/DoomRPG-RLArsenal-Extended/ANIMDEFS.txt
+++ b/DoomRPG-RLArsenal-Extended/ANIMDEFS.txt
@@ -57,3 +57,12 @@ texture BUNKA1
 	pic BUNKB1 tics 6
 	pic BUNKC1 tics 6
 	pic BUNKD1 tics 6
+
+// --------------------------------------------------
+// ITEMS
+// 
+
+// Radar Device
+texture SNRBB0
+	pic SNRBB0 tics 8
+	pic SNRBC0 tics 8

--- a/DoomRPG-RLArsenal-Extended/zscript/DRLAX/Items.zscript
+++ b/DoomRPG-RLArsenal-Extended/zscript/DRLAX/Items.zscript
@@ -1751,7 +1751,7 @@ class DRLAX_CursedDagger : DRLAX_BaseInventory
 
 	override void Tick()
 	{
-		if(level.Time == 5)
+		if(Level.MapName != "OUTPOST" && Level.MapName != "VR" && Level.MapName != "HUBMAP" && level.Time == 5)
 		{
 			if(owner && owner.health > 10)
 			{
@@ -1759,6 +1759,7 @@ class DRLAX_CursedDagger : DRLAX_BaseInventory
 
 				owner.health = 10;
 				owner.player.health = 10;
+                owner.ACS_NamedExecuteAlways("DRLAX_DRPG_CursedDagger_Effect");
 				owner.A_Pain();
 
 				owner.A_Quake(6, 10, 0, 32, "");
@@ -1774,7 +1775,7 @@ class DRLAX_CursedDagger : DRLAX_BaseInventory
 						"RLUnmakerWorldSpawnPickup",
 						"RLHellsReignWorldSpawnPickup"
 					};
-					CMMSS_Actor_SafeSpawner ss = CMMSS_SafeSpawner.New(demonweps[random(0, demonweps.Size()-1)], 1, "", 32, 32, 0, CMMSS_SafeSpawner.SSFLAGS_NOMONSTERS);
+					CMMSS_Actor_SafeSpawner ss = CMMSS_SafeSpawner.New("DRPGWeaponDemonicSpawner", 1, "", 32, 32, 0, CMMSS_SafeSpawner.SSFLAGS_NOMONSTERS);
 					
 					DetachFromOwner();
 					Destroy();
@@ -2202,7 +2203,7 @@ class DRLAX_LegendaryIdol : DRLAX_BaseInventory
 
 	override void Tick()
 	{
-		if(level.Time == 5)
+		if(Level.MapName != "OUTPOST" && Level.MapName != "VR" && Level.MapName != "HUBMAP" && level.Time == 5)
 		{
 			if(owner && owner.health > 0)
 			{
@@ -2221,7 +2222,7 @@ class DRLAX_LegendaryIdol : DRLAX_BaseInventory
 						"RLDuke2RifleWorldSpawnPickup",
 						"RLLonghornWorldSpawnPickup"
 					};
-					CMMSS_Actor_SafeSpawner ss = CMMSS_SafeSpawner.New(legendaryweps[random(0, legendaryweps.Size()-1)], 1, "", 32, 32, 0, CMMSS_SafeSpawner.SSFLAGS_NOMONSTERS);
+					CMMSS_Actor_SafeSpawner ss = CMMSS_SafeSpawner.New("DRPGWeaponLegendarySpawner", 1, "", 32, 32, 0, CMMSS_SafeSpawner.SSFLAGS_NOMONSTERS);
 					
 					//DetachFromOwner();
 					//Destroy();

--- a/DoomRPG-RLArsenal-Extended/zscript/DRLAX/classes/Nomad.zscript
+++ b/DoomRPG-RLArsenal-Extended/zscript/DRLAX/classes/Nomad.zscript
@@ -152,7 +152,9 @@ Class RLNomadEvents : EventHandler
 
 						if(inv.GetClassName() == "RLDangerLevel"){continue;}
 						if(inv.GetClassName() == "RLUniqueBossLevel"){continue;}
-						if(inv.GetClassName() == "RLDemonArtifactItem"){continue;}
+						if(inv.GetClassName() == "DRLAX_FamiliarManager"){continue;}
+						if(inv.GetClassName() == "DRLAX_FamiliarPassive"){continue;}
+						if(inv.GetClassName() == "DRLAX_FamiliarKill"){continue;}
 
 						if(inv.GetClassName() == "PMGameLevel"){continue;}
 
@@ -237,7 +239,18 @@ Class RLNomadEvents : EventHandler
 						if(inv.GetClassName() == "DRLAX_TrappedAGHSphere"){continue;} 					// trapped agh sphere
 						if(inv.GetClassName() == "DRLAX_TrappedFirebluSphere"){continue;} 				// trapped fireblu sphere
 
-						if(inv.GetClassName() == "DRLAX_RadarDevice"){continue;} 						// radar
+						if(inv.GetClassName() == "DRLAX_SmokeBomb"){continue;} 							// smoke bomb
+						if(inv.GetClassName() == "DRLAX_RadarDevice"){continue;} 						// radar device
+						if(inv.GetClassName() == "DRLAX_SawArm"){continue;} 							// auto-saw arm
+						if(inv.GetClassName() == "DRLAX_CursedDagger"){continue;} 						// cursed dagger
+						if(inv.GetClassName() == "DRLAX_DevilMark"){continue;} 							// abyss trophy
+						if(inv.GetClassName() == "DRLAX_LegendaryIdol"){continue;} 						// legendary idol
+
+						if(inv.GetClassName() == "DRLAX_NanoTape"){continue;} 							// nano tape
+						if(inv.GetClassName() == "DRLAX_MagneticCoilKit"){continue;} 					// magnetic coil kit
+						if(inv.GetClassName() == "DRLAX_BarrelCombinerKit"){continue;} 					// barrel combiner kit
+						if(inv.GetClassName() == "DRLAX_ParticleColliderKit"){continue;} 				// particle collider kit
+						if(inv.GetClassName() == "DRLAX_QuantumEngineKit"){continue;} 					// quantum engine kit
 
 						if(inv.GetClassName() == "DRPGShield"){continue;}								// shield
 						if(inv.GetClassName() == "DRPGShieldCharge"){continue;}

--- a/DoomRPG-RLArsenal-Extended/zscript/DRLAX/classes/Trespasser.zscript
+++ b/DoomRPG-RLArsenal-Extended/zscript/DRLAX/classes/Trespasser.zscript
@@ -1,0 +1,641 @@
+class RLTrespasserStartingLoadout : CustomInventory
+{
+	states
+	{
+		Pickup:
+		TNT1 A 0 A_GiveInventory("DRLAX_TrespasserScanner", 1);
+		TNT1 A 0 A_GiveInventory("DRLAX_ShavedArms", 1);
+		TNT1 A 0 A_GiveInventory("DRLAX_TrespasserScatterShot", 1);
+		stop;
+	}
+}
+
+Class RLTrespasserEvents : EventHandler
+{
+	override void RenderOverlay (RenderEvent event)
+    {
+        if(automapactive)
+        {
+            return;
+        }
+        
+        let s = DRLAX_TrespasserSmokeBombCooldown(players[consoleplayer].mo.FindInventory("DRLAX_TrespasserSmokeBombCooldown"));
+
+        if(s)
+        {
+            int aspectoffs;
+
+            let window_aspect    = 1.0 * Screen.GetWidth() / Screen.GetHeight();
+            let resolution        = 480 * (window_aspect, 1);
+			double alpha;
+			if(s.GetAge() < 55 * 35)
+			{
+				alpha = 0.25;
+			}
+			else
+			{
+				alpha = Max(0.1, Abs(cos(s.GetAge() * 4)) - 0.1);
+			}
+			//Console.Printf("" .. Abs(cos(s.GetAge() * 5)));
+
+            Screen.DrawTexture(TexMan.CheckForTexture("TRSMKCD", TexMan.Type_Sprite, 0), false, 692, 65,
+			DTA_ALPHA, alpha,
+            DTA_VIRTUALWIDTHF,    resolution.x,
+            DTA_VIRTUALHEIGHTF,    resolution.y,
+            DTA_KEEPRATIO, true, DTA_HUDRules);
+        }
+    }
+
+	void SplinterShot(int damage, actor hitactor, actor playeractor, int angle, String damagetype)
+	{
+		if(hitactor)
+		{
+			for(int i=0; i<Min(damage*0.1, 20); i++)
+			{
+				FLineTraceData RemoteRay;
+				bool hit = hitactor.LineTrace(
+				angle + frandom(-20.0, 20.0),
+				900,
+				0,
+				offsetz: frandom(- 8, hitactor.height + 8),
+				data: RemoteRay
+				);
+
+				if (hit)
+				{
+					if(RemoteRay.HitType == TRACE_HitWall)
+					{
+						if(damagetype ~== "Bullet")
+						{
+							SpawnPuff("DRLAX_SplinterShot", RemoteRay.HitLocation, playeractor);
+						}
+						else if(damagetype ~== "Fire")
+						{
+							SpawnPuff("DRLAX_SplinterShotFire", RemoteRay.HitLocation, playeractor);
+						}
+						else if(damagetype ~== "Plasma")
+						{
+							SpawnPuff("DRLAX_SplinterShotPlasma", RemoteRay.HitLocation, playeractor);
+						}
+						else if(damagetype ~== "Unholy")
+						{
+							SpawnPuff("DRLAX_SplinterShotUnholy", RemoteRay.HitLocation, playeractor);
+						}
+						else if(damagetype ~== "Holy")
+						{
+							SpawnPuff("DRLAX_SplinterShotPlasma", RemoteRay.HitLocation, playeractor);
+						}
+						else
+						{
+							SpawnPuff("DRLAX_SplinterShot", RemoteRay.HitLocation, playeractor);
+						}
+					}
+				}			
+			}
+
+			Array<Actor> hits;
+
+			for(int h = 0; h<3; h++)
+			{
+				for(int i = 0; i<61; i++)
+				{
+					if(i%2 == 0)
+					{
+						continue;
+					}
+
+					FLineTraceData RemoteRay;
+					bool hit = hitactor.LineTrace(
+					(angle - 30) + i,
+					900,
+					0,
+					offsetz: (hitactor.height * 0.5) * h,
+					data: RemoteRay
+					);
+
+					//Actor.Spawn("HealthBonus", RemoteRay.HitLocation);
+
+					if(RemoteRay.HitType == TRACE_HitActor)
+					{
+						Actor v = RemoteRay.HitActor;
+
+						if(v && hits.Find(v) == hits.Size())
+						{
+							if(v.player && !deathmatch)
+							{
+								continue;
+							}
+
+							v.DamageMobj(hitactor, playeractor, damage * 0.7, damagetype, DMG_USEANGLE, angle);
+							if(v.BloodType && !v.bNOBLOOD)
+							{
+								v.SpawnBlood(RemoteRay.HitLocation, angle, damage);
+							}
+							hits.Push(v);
+						}
+					}
+				}
+			}
+		}
+	}
+
+	/* old splinter shot
+	
+	void SplinterShot(int damage, actor hitactor, actor playeractor, int angle, String damagetype)
+	{
+		if(hitactor)
+		{
+			for(int i; i<Max(1, Min(damage / 4, 256)); i++)
+			{
+				FLineTraceData RemoteRay;
+				bool hit = hitactor.LineTrace(
+				angle + frandom(-20.0, 20.0),
+				3000,
+				frandom(-6.0, 6.0),
+				offsetz: hitactor.height * 0.5,
+				data: RemoteRay
+				);
+
+				if (hit)
+				{
+					if(RemoteRay.HitType == TRACE_HitWall)
+					{
+						if(damagetype ~== "Bullet")
+						{
+							SpawnPuff("DRLAX_SplinterShot", RemoteRay.HitLocation, playeractor);
+						}
+						else if(damagetype ~== "Fire")
+						{
+							SpawnPuff("DRLAX_SplinterShotFire", RemoteRay.HitLocation, playeractor);
+						}
+						else if(damagetype ~== "Plasma")
+						{
+							SpawnPuff("DRLAX_SplinterShotPlasma", RemoteRay.HitLocation, playeractor);
+						}
+						else if(damagetype ~== "Unholy")
+						{
+							SpawnPuff("DRLAX_SplinterShotUnholy", RemoteRay.HitLocation, playeractor);
+						}
+						else if(damagetype ~== "Holy")
+						{
+							SpawnPuff("DRLAX_SplinterShotPlasma", RemoteRay.HitLocation, playeractor);
+						}
+						else
+						{
+							SpawnPuff("DRLAX_SplinterShot", RemoteRay.HitLocation, playeractor);
+						}
+					}
+
+					if(RemoteRay.HitType == TRACE_HitActor)
+					{
+						Actor v = RemoteRay.HitActor;
+
+						if(v)
+						{
+							v.DamageMobj(hitactor, playeractor, 6, damagetype, DMG_USEANGLE, angle);
+							v.SpawnBlood(RemoteRay.HitLocation, angle, damage);
+						}
+					}
+				}
+			}
+		}
+	}
+	*/
+
+	void SpawnPuff(String puff, Vector3 pos, Actor source)
+	{
+		Vector3 newpos = pos - source.pos;
+		newpos = pos - (newpos * 0.01);
+		Actor.Spawn(puff, newpos);
+	}
+
+	static const String PlasmaPistolProj[] = 
+		{
+		"RLPlasmaPistolBall", 
+		"RLPlasmaCombatPistolBall",
+		"RLPlasmaMarksmanPistolBall",
+		"RLPlasmaHandcannonBall",
+		"RLPlasmaUziBall",
+		"RLSuperchargedNuclearPlasmaPistolBall",
+		"RLNuclearPlasmaRevolverBall",
+		"RLNuclearPlasmaPistolBall",
+		"RLBaronBlasterBall",
+		"RLNeuralStunnerBlast"
+		};
+	
+	static const String RocketPistolProj[] = 
+		{
+		"RLMiniMissile",
+		"RLUnknownHeraldRocket",
+		"RLJackalTracerBullet",
+		"RLCasullTracerBullet"
+		};
+
+	static const String DemoPuff[]=
+	{
+		"RLDemoPistolPuff",
+		"RLDemoCombatPistolPuff",
+		"RLDemoMarksmanPistolPuff",
+		"RLDemoHandcannonPuff",
+		"RLDemoUziPuff"
+	};
+
+    override void WorldThingDied(WorldEvent e)
+    {
+        if(e.Thing && !e.Thing.player && e.Thing.bSHOOTABLE && e.Thing.bISMONSTER && e.Thing.target && e.inflictor && !e.Inflictor.bISMONSTER)
+		{
+            if(e.Thing.target is "DoomRLTrespasser" && e.Thing.target.CountInv("DRLAX_TrespasserSmokeBombCooldown") == 0)
+            {
+                if(e.Inflictor.damagetype == "Melee" || e.inflictor.GetClassName() == "RLEnergySawPuff")
+                {
+                    e.Thing.target.A_SpawnItemEx("DRLAX_SmokeBombActivate", flags:SXF_NOCHECKPOSITION);
+					e.Thing.target.GiveInventory("DRLAX_TrespasserSmokeBombCooldown", 1);
+                }
+            }
+        }
+
+		if(e.Thing && e.Thing.GetClassName() == "RLSupplyCrate")
+		{
+			ThinkerIterator i = ThinkerIterator.Create("DRLAX_TrespasserScanner");
+			DRLAX_TrespasserScanner inv;
+			while(inv = DRLAX_TrespasserScanner(i.Next()))
+			{
+				if(inv.levels.Find(Level.LevelName) == inv.levels.Size())
+				{
+					if(random(0, 4) == 0)
+					{
+						inv.levels.Push(Level.LevelName);
+						Actor a = Actor.Spawn(inv.armor, e.Thing.pos);
+						if(a)
+						{
+							e.Thing.A_StartSound("items/newitemspawn", CHAN_6, attenuation:0.5);
+							a.A_ChangeVelocity(random(-5, 5), random(-5, 5), random(5, 9));
+						}
+					}
+				}
+			}
+		}
+    }
+	
+	override void WorldThingDamaged (WorldEvent e)
+	{
+		if(e.Thing && !e.Thing.player && e.Thing.bSHOOTABLE && e.DamageSource)
+		{
+			Actor a = e.DamageSource;
+
+            if(a.CountInv("DRLAX_TrespasserScatterShot") == 0)
+            {
+                return;
+            }
+
+			//Console.Printf("" .. a.GetCLassName());
+
+			let p = players[a.PlayerNumber()];
+
+			//Console.Printf(p.ReadyWeapon.GetClassName());
+
+			if(e.inflictor && e.inflictor.GetClassName() == "DRLAX_TrespasserFamiliar")
+			{
+				SplinterShot(e.damage, e.Thing, a, e.inflictor.angle, "Bullet");
+				return;
+			}
+
+            if(p && e.DamageFlags & DMG_PLAYERATTACK)
+            {
+                if(p.ReadyWeapon is "RLPistolWeapon")
+                {
+                    //Console.Printf("" .. e.damage);
+                    SplinterShot(e.damage, e.Thing, a, e.DamageAngle, e.Damagetype);
+					return;
+                }
+
+				if(p.ReadyWeapon is "RLDeathsGaze")
+				{
+					SplinterShot(e.damage, e.Thing, a, e.DamageAngle, "Unholy");
+					return;
+				}
+            }
+
+
+			//Console.Printf("" .. e.Inflictor.GetClassName());
+
+			if(a.player && e.Inflictor)
+			{
+				for(int i = 0; i< PlasmaPistolProj.Size(); i++)
+				{
+					if(e.Inflictor is (PlasmaPistolProj[i]))
+					{
+						//Console.Printf("" .. e.damage);
+						SplinterShot(e.damage, e.Thing, a, e.inflictor.angle, "Plasma");
+						return;
+					}
+				}
+
+				for(int i = 0; i< RocketPistolProj.Size(); i++)
+				{
+					if(e.Inflictor is (RocketPistolProj[i]))
+					{
+						//Console.Printf("" .. e.damage);
+						SplinterShot(e.damage, e.Thing, a, e.inflictor.angle, "Fire");
+						return;
+					}
+				}
+
+				for(int i = 0; i< DemoPuff.Size(); i++)
+				{
+					if(e.Inflictor is (DemoPuff[i]))
+					{
+						//Console.PRintf("Thing = " ..  e.Thing.GetClassName() .. " inflictor = " .. e.inflictor.GetClassName() .. " - source = " .. a.GetClassName());
+						SplinterShot(e.damage, e.Thing, a, e.inflictor.angle + 180, "Fire");
+						return;
+					}
+				}
+			}
+		}
+	}
+}
+/*
+class testdummy : Cacodemon
+{
+	Default
+	{
+		health 9999999999;
+		+NODAMAGETHRUST;
+		mass 99999999999;
+	}
+
+
+	states
+	{
+		Pain:
+		"####" "#" -1;
+		stop;
+	}
+}
+*/
+class DRLAX_SplinterShot : Actor
+{
+	Default
+	{
+		+NOINTERACTION;
+		+NOGRAVITY;
+		radius 2;
+		height 2;
+		scale 0.5;
+		+BRIGHT;
+		translation "CMMDRLA_Splinter";
+		+ROLLSPRITE;
+	}
+
+	states
+	{
+		Spawn:
+		TNT1 A 0;
+		TNT1 A 0 A_SetTics(random(0, 3));
+		TRSH ABC 3;
+		TNT1 A 5;
+		stop;
+	}
+
+	override void PostBeginPlay()
+	{
+		A_StartSound("trespasser/splinterhit");
+		roll = random(0,360);
+	}
+}
+
+class DRLAX_SplinterShotPlasma : DRLAX_SplinterShot
+{
+	Default
+	{
+		translation "CMMDRLA_SplinterPlasma";
+	}
+}
+
+class DRLAX_SplinterShotFire : DRLAX_SplinterShot
+{
+	Default
+	{
+		translation "CMMDRLA_SplinterFire";
+	}
+}
+
+class DRLAX_SplinterShotUnholy : DRLAX_SplinterShot
+{
+	Default
+	{
+		translation "CMMDRLA_SplinterUnholy";
+	}
+}
+
+class DRLAX_TrespasserSmokeBombCooldown : Powerup
+{
+	Default
+	{
+		powerup.duration -60;
+	}
+
+	override void EndEffect()
+	{
+		if(owner && owner.health > 0)
+		{
+			owner.A_StartSound("trespasser/stealthready", slot:CHAN_6, volume:0.8);
+		}
+		Super.EndEffect();
+	}
+}
+
+// In ACS
+// 
+
+//Str item = ScriptCall("DRLAX_DRPG_Functions", "GetTrespasserScans", playerno);
+
+class DRLAX_DRPG_Functions
+{
+    static String GetTrespasserScans(int playerno)
+    {
+		if(players[playerno].mo)
+		{
+			let inv = DRLAX_TrespasserScanner(players[playerno].mo.FindInventory("DRLAX_TrespasserScanner"));
+			if(inv)
+			{
+				return inv.armor.GetClassName();
+			}
+		}
+
+        return "";
+    }
+}
+
+class DRLAX_TrespasserScanner : DRLAX_BaseInventory
+{
+	Default
+	{
+		Inventory.Icon "TRESSCAN";
+		inventory.maxamount 1;
+		Inventory.InterhubAmount 1;
+		inventory.pickupsound "";
+		Inventory.UseSound "";
+		Inventory.PickupMessage "You picked up Trespasser's Scanner SOMEHOW?.";
+		//species "Player";
+		tag "Loot Tracker";
+	}
+
+	Class<Actor> armor;
+	String armorname;
+	Array<String> levels;
+
+	override void PressedDrop()
+	{
+		
+	}
+
+	override void ConsumeItem()
+	{
+
+	}
+
+	override void DropMessage()
+	{
+		owner.A_Print("This item cannot be dropped.");
+	}
+
+	override void UseMessage()
+	{
+		if(owner.CountInv("DRLAX_TrespasserScannerCooldown") > 0)
+		{
+			return;
+		}
+
+		owner.A_Print("Use the Tracker again to scan nearby items to have an increased chance of finding them inside crates.\n\cfCurrently tracking: \cv" .. armorname .. "\c-\n\nSwitch weapons to cancel scan.", 8.0);
+		//owner.A_PlaySound("hud/generic");
+	}
+
+	override void UseSound()
+	{
+		if(owner.CountInv("DRLAX_TrespasserScannerCooldown") > 0)
+		{
+			return;
+		}
+
+		owner.A_StartSound("UI/PDA/UseCategory", flags:CHANF_LOCAL);
+	}
+
+	bool ValidItem(Actor i)
+	{
+		return (i is "RLGenericArmorPickup" || i is "RLGenericBootsPickup" || i is "RLStandardWeaponPickup" || 
+		i is "RLExoticWeaponPickup" || i is "RLSuperiorWeaponPickup" || i is "RLUniqueWeaponPickup" || i is "RLDemonicWeaponPickup" ||
+		i is "RLLegendaryWeaponPickup");
+	}
+
+
+	override void UseFunction()
+	{
+		if(owner.CountInv("DRLAX_TrespasserScannerCooldown") > 0)
+		{
+			return;
+		}
+
+		owner.A_Print("");
+
+		BlockThingsIterator bti = BlockThingsIterator.Create(owner, 256);
+        while(bti.Next())
+        {
+            CustomInventory i = CustomInventory(bti.Thing);
+
+            if(i && ValidItem(i) && i.Distance3D(owner) <= 150 && i.CheckSight(owner))
+            {
+				if(i.GetTag().IndexOf("[O]",0) > 0)
+				{
+					continue;
+				}
+
+				armor = i.GetClass();
+				armorname = i.GetTag();
+
+				armorname.Replace(" [Pickup]", "");
+
+				owner.GiveInventory("DRLAX_TrespasserScannerCooldown", 1);
+				Spawn("DRLAX_TrespasserScannerScanning", i.pos);
+				owner.A_Print("\c-Scan successful. Now tracking: \cv" .. armorname .. "\c-.", 8.0);
+				owner.A_PlaySound("hud/assemblyconfirm");
+		
+                return;
+            }
+		}
+
+		owner.A_Print("No valid items nearby.");
+	}
+
+	override void PostBeginPlay()
+	{
+		armorname = "Combat Armor";
+		String s = "RLBlueArmorPickup";
+		armor = s;
+	}
+}
+
+Class DRLAX_TrespasserScannerCooldown : Powerup
+{
+	Default
+	{
+		powerup.duration -3;
+	}
+}
+
+Class DRLAX_TrespasserScannerScanning : Actor
+{
+	Default
+	{
+		+NOINTERACTION;
+		+NOGRAVITY;
+	}
+
+	states
+	{
+		Spawn:
+		TNT1 AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA 1 
+		{
+			A_SpawnItemEx("DRLAX_TrespasserScannerFX", 16, 0, random(0, 40), 0, 0, 0, random(0, 360), SXF_NOCHECKPOSITION);
+			A_SpawnItemEx("DRLAX_TrespasserScannerFX", 16, 0, random(0, 40), 0, 0, 0, random(0, 360), SXF_NOCHECKPOSITION);
+		}
+		stop;
+	}
+}
+
+Class DRLAX_TrespasserScannerFX : Actor
+{
+	Default
+	{
+		+BRIGHT;
+		height 2;
+		radius 2;
+		scale 0.5;
+		+NOINTERACTION;
+		+NOGRAVITY;
+	}
+
+	states
+	{
+		Spawn:
+		TRSH D 0;
+		TRSH E 1;
+		loop;
+	}
+
+	override void Tick()
+	{
+		A_SetTics(random(1, 5));
+		A_FadeOut(0.07);
+		Super.Tick();
+	}
+}
+
+Class DRLAX_TrespasserScatterShot : Inventory
+{
+	Default
+    {
+		+INVENTORY.UNDROPPABLE;
+		+INVENTORY.UNTOSSABLE;
+    }
+}

--- a/DoomRPG-RLArsenal/actors/doomrl/Randomizers.txt
+++ b/DoomRPG-RLArsenal/actors/doomrl/Randomizers.txt
@@ -401,6 +401,28 @@ actor DRPGWeaponUniqueSpawner : MapSpot
     }
 }
 
+// Weapon Demonic Randomizer
+actor DRPGWeaponDemonicSpawner : MapSpot
+{
+    States
+    {
+    Spawn:
+        TNT1 A -1 NoDelay ACS_NamedExecuteWithResult("DRPGWeaponDemonicSpawner")
+        Stop
+    }
+}
+
+// Weapon Legendary Randomizer
+actor DRPGWeaponLegendarySpawner : MapSpot
+{
+    States
+    {
+    Spawn:
+        TNT1 A -1 NoDelay ACS_NamedExecuteWithResult("DRPGWeaponLegendarySpawner")
+        Stop
+    }
+}
+
 // Weapon Dropper
 actor DRPGWeaponDropper2 : RandomSpawner Replaces DRPGWeaponDropper
 {

--- a/DoomRPG/GAMEINFO.txt
+++ b/DoomRPG/GAMEINFO.txt
@@ -1,3 +1,3 @@
-startuptitle = "Doom RPG SE Rebalance (2023-08-31)"
+startuptitle = "Doom RPG SE Rebalance (2023-09-02)"
 startupcolors = "0092FF", "000000"
 startuptype = "Hexen"

--- a/DoomRPG/scripts/ItemData.c
+++ b/DoomRPG/scripts/ItemData.c
@@ -913,8 +913,12 @@ NamedScript void BuildItemData()
         // Compatibility Handling - DoomRL Arsenal Extended
         if (CompatModeEx == COMPAT_DRLAX)
         {
+            ITEMDATA_DEF("DRLAX_SmokeBomb",         "Smoke Bomb",                           250,  1,  1, "SMKBA0",  9, 14);
             ITEMDATA_DEF("DRLAX_SoulTrap",          "Soul Trap",                           1000,  2,  1, "SNRBD0", 12, 21);
-            ITEMDATA_DEF("DRLAX_RadarDevice",       "Radar",                               1000,  2,  1, "SNRBB0",  9, 18);
+            ITEMDATA_DEF("DRLAX_RadarDevice",       "Radar Device",                        3000,  2,  2, "SNRBB0",  9, 18);
+            ITEMDATA_DEF("DRLAX_SawArm",            "Auto-Saw Arm",                       10000,  5,  6, "SNRBF0", 14, 11);
+        //    ITEMDATA_DEF("DRLAX_CursedDagger",      "\CgCursed Dagger\C-",                25000, -1,  -1, "SNRBG0", 20, 18);
+        //    ITEMDATA_DEF("DRLAX_DevilMark",         "Abyss Trophy",                       50000, -1,  -1, "SNRBH0", 12, 20);
         }
         ITEMDATA_CATEGORY_END;
 
@@ -927,17 +931,28 @@ NamedScript void BuildItemData()
         ITEMDATA_DEF("RLTechnicalModItem",      "Technical Modpack",     25000, 5, 7, "TMODA0",  8, 17);
 
         // Exotic Modpacks
-        ITEMDATA_DEF("RLSniperModItem",         "Sniper Modpack",       50000, 7, 8, "SMODA0",  8, 17);
-        ITEMDATA_DEF("RLFirestormModItem",      "Firestorm Modpack",    50000, 7, 8, "FMODA0",  8, 17);
-        ITEMDATA_DEF("RLNanoModItem",           "Nano Modpack",         50000, 7, 8, "NMODA0",  8, 17);
-        ITEMDATA_DEF("RLOnyxModItem",           "Onyx Modpack",         50000, 7, 8, "OMODA0",  8, 17);
-        ITEMDATA_DEF("RLArmorModItem",          "Armor Modpack",        50000, 7, 8, "AMK1A0", 10, 20);
+        ITEMDATA_DEF("RLSniperModItem",         "Sniper Modpack",        50000, 7, 8, "SMODA0",  8, 17);
+        ITEMDATA_DEF("RLFirestormModItem",      "Firestorm Modpack",     50000, 7, 8, "FMODA0",  8, 17);
+        ITEMDATA_DEF("RLNanoModItem",           "Nano Modpack",          50000, 7, 8, "NMODA0",  8, 17);
+        ITEMDATA_DEF("RLOnyxModItem",           "Onyx Modpack",          50000, 7, 8, "OMODA0",  8, 17);
+        ITEMDATA_DEF("RLArmorModItem",          "Armor Modpack",         50000, 7, 8, "AMK1A0", 10, 20);
 
         // Super rare Modpacks
         //ITEMDATA_DEF("RLArtiModItem",           "Arti Modpack",        100000, 9, 8, "ARTMI0", -7, -5);
 
         // Demon Artifact
-        ITEMDATA_DEF("RLDemonArtifactItem",     "Demon Artifact",     100000, 11, 9, "DMNAA0", 19, 65);
+        ITEMDATA_DEF("RLDemonArtifactItem",     "Demon Artifact",       100000, 11, 9, "DMNAA0", 19, 65);
+
+        // Compatibility Handling - DoomRL Arsenal Extended
+        // Weapon Kits
+        if (CompatModeEx == COMPAT_DRLAX)
+        {
+            ITEMDATA_DEF("DRLAX_NanoTape",             "Nano Tape",               25000,  -1,  3, "SNRBE0",  5, 10);
+            ITEMDATA_DEF("DRLAX_MagneticCoilKit",      "Magnetic Coil Kit",       30000,  -1,  4, "SNRBJ0", 14, 16);
+            ITEMDATA_DEF("DRLAX_BarrelCombinerKit",    "Barrel Combiner Kit",     40000,  -1,  7, "SNRBI0", 14, 16);
+            ITEMDATA_DEF("DRLAX_ParticleColliderKit",  "Particle Collider Kit",   50000,  -1,  7, "SNRBK0", 14, 16);
+            ITEMDATA_DEF("DRLAX_QuantumEngineKit",     "Quantum Engine Kit",      60000,  -1,  7, "SNRBL0", 14, 16);
+        }
 
         // Crates with Parts for craft
         ITEMDATA_DEF("DRPGCraftPartsExotic", "Craft Parts \Ct[Exotic]\C-", 50000, -1, -1, "CREXA", -1, -12);
@@ -1574,7 +1589,6 @@ NamedScript DECORATE void DRPGWeaponUniqueSpawner()
     int Amount;
     int Penalty;
     int Index;
-    int Iterations;
 
     // Calculate Modifier
     if (GetCVar("drpg_loot_type") == 0)
@@ -1608,6 +1622,130 @@ NamedScript DECORATE void DRPGWeaponUniqueSpawner()
         for (int i = 0; i < ItemMax[ItemCategory]; i++)
         {
             if (!ItemSpawned && StrMid(ItemData[ItemCategory][i].Name, StrLen(ItemData[ItemCategory][i].Name) - 9, 6) == "Unique" && ItemData[ItemCategory][i].Rarity >= RarityMin && ItemData[ItemCategory][i].Rarity <= RarityMax)
+            {
+                // Set penalty for an item already spawned
+                if (ItemData[ItemCategory][i].Spawned < 5)
+                    Penalty = ItemData[ItemCategory][i].Spawned;
+                else
+                    Penalty = 5;
+
+                if (Random(0, 100 + (25 * Amount)) <= 50 && Random(0, Penalty * (200 - Penalty * 20)) <= 50)
+                {
+                    // Set weapon index
+                    Index = i;
+
+                    ActorToSpawn = StrParam("%SWorldSpawnPickup", ItemData[ItemCategory][Index].Actor);
+                    ItemSpawned = true;
+                }
+                Amount++;
+            }
+
+            Amount = 0;
+        }
+    }
+
+    if (ItemSpawned)
+        ItemData[ItemCategory][Index].Spawned++;
+
+    SpawnSpotFacingForced(ActorToSpawn, 0, ActivatorTID());
+
+    Thing_Remove(0);
+}
+
+NamedScript DECORATE void DRPGWeaponDemonicSpawner()
+{
+    // Delay while the map is being initialized
+    while (!CurrentLevel->Init) Delay(1);
+
+    str ActorToSpawn;
+    bool ItemSpawned;
+    int ItemCategory;
+    int RarityMin;
+    int RarityMax = 6;
+    int Modifier;
+    int Amount;
+    int Penalty;
+    int Index;
+
+    // Calculate Modifier
+    if (GetCVar("drpg_loot_type") == 0)
+        Modifier = RoundInt(7.5 * MapLevelModifier + 7.5 * (fixed)AveragePlayerLuck() / 100.0);
+    if (GetCVar("drpg_loot_type") == 1)
+        Modifier = RoundInt(15.0 * MapLevelModifier);
+    if (GetCVar("drpg_loot_type") == 2)
+        Modifier = RoundInt(15.0 * (fixed)AveragePlayerLuck() / 100.0);
+    if (GetCVar("drpg_loot_type") == 3)
+        Modifier = Random(0,15);
+    if (Modifier > 15)
+        Modifier = 15;
+
+    // Calculate Rarity Max
+    for (int i = RarityMax; i < 10; i++)
+        if (Random(0, Random(3, 7) + RarityMax - Modifier) <= 0)
+            RarityMax++;
+    if (RarityMax > 1 + RoundInt(10.0 * MapLevelModifier))
+        RarityMax = 1 + RoundInt(10.0 * MapLevelModifier);
+    if (RarityMax < 6) // Make sure the Rarity still at least 6, or else bad things will happen
+        RarityMax = 6;
+    if (RarityMax > 10)
+        RarityMax = 10;
+
+    // Calculate Rarity Min
+    if (RarityMax > 1)
+        RarityMin = Random(RarityMax / 4, RarityMax - 1);
+
+    while (!ItemSpawned)
+    {
+        for (int i = 0; i < ItemMax[ItemCategory]; i++)
+        {
+            if (!ItemSpawned && StrMid(ItemData[ItemCategory][i].Name, StrLen(ItemData[ItemCategory][i].Name) - 10, 7) == "Demonic" && ItemData[ItemCategory][i].Rarity >= RarityMin && ItemData[ItemCategory][i].Rarity <= RarityMax)
+            {
+                // Set penalty for an item already spawned
+                if (ItemData[ItemCategory][i].Spawned < 5)
+                    Penalty = ItemData[ItemCategory][i].Spawned;
+                else
+                    Penalty = 5;
+
+                if (Random(0, 100 + (25 * Amount)) <= 50 && Random(0, Penalty * (200 - Penalty * 20)) <= 50)
+                {
+                    // Set weapon index
+                    Index = i;
+
+                    ActorToSpawn = StrParam("%SWorldSpawnPickup", ItemData[ItemCategory][Index].Actor);
+                    ItemSpawned = true;
+                }
+                Amount++;
+            }
+
+            Amount = 0;
+        }
+    }
+
+    if (ItemSpawned)
+        ItemData[ItemCategory][Index].Spawned++;
+
+    SpawnSpotFacingForced(ActorToSpawn, 0, ActivatorTID());
+
+    Thing_Remove(0);
+}
+
+NamedScript DECORATE void DRPGWeaponLegendarySpawner()
+{
+    // Delay while the map is being initialized
+    while (!CurrentLevel->Init) Delay(1);
+
+    str ActorToSpawn;
+    bool ItemSpawned;
+    int ItemCategory;
+    int Amount;
+    int Penalty;
+    int Index;
+
+    while (!ItemSpawned)
+    {
+        for (int i = 0; i < ItemMax[ItemCategory]; i++)
+        {
+            if (!ItemSpawned && StrMid(ItemData[ItemCategory][i].Name, StrLen(ItemData[ItemCategory][i].Name) - 12, 9) == "Legendary")
             {
                 // Set penalty for an item already spawned
                 if (ItemData[ItemCategory][i].Spawned < 5)

--- a/DoomRPG/scripts/Utils.c
+++ b/DoomRPG/scripts/Utils.c
@@ -443,6 +443,20 @@ NamedScript DECORATE int CheckCapacity()
             "DRLAX_FamiliarBall",
             "DRLAX_RadarDevice",
             "DRLAX_SoulTrap",
+            "DRLAX_SmokeBomb",
+            "DRLAX_NanoTape",
+            "DRLAX_SawArm",
+            "DRLAX_CursedDagger",
+            "DRLAX_DevilMark",
+
+            // DoomRLAX - Weapon Kits
+            "DRLAX_BarrelCombinerKit",
+            "DRLAX_ParticleColliderKit",
+            "DRLAX_MagneticCoilKit",
+            "DRLAX_QuantumEngineKit",
+
+            // DoomRLAX - Legendary Idol
+            "DRLAX_LegendaryIdol",
 
             // DoomRLAX - Trapped Soul Spheres
             "DRLAX_TrappedInvulnerabilitySphere",
@@ -2890,6 +2904,11 @@ NamedScript DECORATE void PhaseSistersShieldPartsLoad()
             }
         }
     }
+}
+
+NamedScript DECORATE void DRLAX_DRPG_CursedDagger_Effect()
+{
+    Player.ActualHealth = 10;
 }
 
 // --------------------------------------------------


### PR DESCRIPTION
Update DoomRL Arsenal Extended 1.1c compatibility:
- added Trespasser's scan item perk in DoomRPG crates system;
- added new items in shop/locker (some items can only be found on maps, but you can now sell/save them);
- fix: now cursed dagger takes away health up to 10 according to the description.