### PR TITLE
Update 1.33 hotfix 4

### DIFF
--- a/DoomRPG-RLArsenal-Extended/zscript/DRLAX/Items.zscript
+++ b/DoomRPG-RLArsenal-Extended/zscript/DRLAX/Items.zscript
@@ -1759,7 +1759,7 @@ class DRLAX_CursedDagger : DRLAX_BaseInventory
 
 				owner.health = 10;
 				owner.player.health = 10;
-                owner.ACS_NamedExecuteAlways("DRLAX_DRPG_CursedDagger_Effect");
+                owner.ACS_NamedExecuteAlways("SetPlayerActualHealth", 0, 10);
 				owner.A_Pain();
 
 				owner.A_Quake(6, 10, 0, 32, "");

--- a/DoomRPG-RLArsenal-Extended/zscript/DRLAX/classes/Bunker.zscript
+++ b/DoomRPG-RLArsenal-Extended/zscript/DRLAX/classes/Bunker.zscript
@@ -1,0 +1,1316 @@
+class RLBunkerStartingLoadout : CustomInventory
+{
+	states
+	{
+		Pickup:
+        TNT1 A 0 A_TakeInventory("Clip", 60);
+		TNT1 A 0 A_TakeInventory("RLPistol", 1);
+		TNT1 A 0 A_GiveInventory("RLBlaster", 1);
+		TNT1 A 0 A_GiveInventory("Cell", 200);
+        TNT1 A 0 A_SelectWeapon("RLBlaster");
+		TNT1 A 0 A_GiveInventory("DRLAX_BunkerShield", 1);
+        TNT1 A 0 A_GiveInventory("DRLAX_BunkerRicochet", 1);
+		stop;
+	}
+}
+
+
+Class RLBunkerEvents : StaticEventHandler
+{
+    override void WorldThingSpawned(WorldEvent e)
+    {
+        if(e.Thing && e.Thing is "Rocket" && e.Thing.target && e.Thing.target.player)
+        {
+            DRLAX_BunkerRicochet r = DRLAX_BunkerRicochet(e.Thing.target.FindInventory("DRLAX_BunkerRicochet"));
+            if(r && !r.off)
+            {
+                DLRAX_BunkerRocketHelper h = new ("DLRAX_BunkerRocketHelper");
+                h.rocket = e.Thing;
+                h.Init();
+            }
+        }
+    }
+
+    override void WorldThingDamaged (WorldEvent e) 
+    {
+        DRLAX_BunkerRicochet r = DRLAX_BunkerRicochet(players[consoleplayer].mo.FindInventory("DRLAX_BunkerRicochet"));
+
+        if(r && !r.off && e.Thing && e.inflictor && e.damagesource)
+        {
+            if(e.inflictor is "Rocket" && e.DamageFlags & DMG_EXPLOSION)
+            {
+                e.Thing.DamageMobj(e.inflictor, e.damagesource, e.damage * 0.25, e.damagetype, DMG_THRUSTLESS|DMG_NO_PAIN);
+            }
+        }
+    }
+
+    override void RenderOverlay (RenderEvent event)
+    {
+        if(automapactive)
+        {
+            return;
+        }
+        
+        DRLAX_BunkerShield s = DRLAX_BunkerShield(players[consoleplayer].mo.FindInventory("DRLAX_BunkerShield"));
+
+        if(s && players[consoleplayer].mo)
+        {
+            
+            bool haschaingun;
+
+            for(int i; i<DRLAX_BunkerShield.Chainguns.Size(); i++)
+            {
+                if(players[consoleplayer].ReadyWeapon is (DRLAX_BunkerShield.Chainguns[i]))
+                {
+                    haschaingun = true;
+                    break;
+                }
+            }
+
+            if(s.onyxgot[s.ONYX_DUELIST] && players[consoleplayer].ReadyWeapon is "RLPistolWeapon")
+            {
+                haschaingun = true;
+            }
+
+			int X = CVar.GetCVar("drpg_drla_x", players[consoleplayer]).GetInt();
+			int Y = CVar.GetCVar("drpg_drla_y", players[consoleplayer]).GetInt();   
+			int XOff = - 140, YOff = - 10;	
+
+            if(Screen.GetAspectRatio() < 1.3)
+            {
+                XOff = - 279;
+                YOff = + 5;
+            }
+            else if(Screen.GetAspectRatio() < 1.4)
+            {
+                XOff = - 248;
+                YOff = - 10;
+            }
+            else if(Screen.GetAspectRatio() < 1.7)
+            {
+                XOff = - 183;
+                YOff = - 10;
+            }
+            else if(Screen.GetAspectRatio() < 1.8)
+            {
+                XOff = - 140;
+                YOff = - 10;
+            }			
+            else if(Screen.GetAspectRatio() > 2.3)
+            {
+                XOff = + 2;
+                YOff = - 10;
+            }
+
+            let window_aspect    = 1.0 * Screen.GetWidth() / Screen.GetHeight();
+            let resolution        = 480 * (window_aspect, 1);
+
+            if(haschaingun)
+            {
+            Screen.DrawTexture(TexMan.CheckForTexture("BUNKRCEL", TexMan.Type_Sprite, 0), false, X + XOff + 2, Y + YOff,
+            DTA_VIRTUALWIDTHF,    resolution.x,
+            DTA_VIRTUALHEIGHTF,    resolution.y,
+            DTA_KEEPRATIO, true, DTA_HUDRules);
+
+            String cellammo = "" .. s.owner.CountInv("Cell");
+
+            let cf = Font.CR_GOLD;
+
+            if(players[consoleplayer].mo.CountInv("Cell") < 3)
+            {
+                cf = Font.CR_RED;
+            }
+
+            Screen.DrawText("CONFONT", cf, X + XOff + 20, Y + YOff, cellammo, 
+            DTA_VIRTUALWIDTHF,    resolution.x,
+            DTA_VIRTUALHEIGHTF,    resolution.y,
+            DTA_KEEPRATIO, true, DTA_HUDRules);
+
+                        
+            TextureID shieldbar = TexMan.CheckForTexture("BUNKEN" .. Max(0, (s.shieldhealth / 64)), TexMan.Type_Sprite, 0);
+            //Console.Printf("" .. Max(0, (s.shieldhealth / 64)));
+            Screen.DrawTexture(shieldbar, false, X + XOff, Y + YOff + 15,
+            DTA_VIRTUALWIDTHF,    resolution.x,
+            DTA_VIRTUALHEIGHTF,    resolution.y,
+            DTA_KEEPRATIO, true, DTA_HUDRules);
+
+            if(players[consoleplayer].mo.CountInv("DRLAX_BunkerDamageNotification") > 0)
+            {
+                TextureID hurtbar = TexMan.CheckForTexture("BUNKENX", TexMan.Type_Sprite, 0);
+                Screen.DrawTexture(hurtbar, false, X + XOff, Y + YOff + 15,
+                DTA_VIRTUALWIDTHF,    resolution.x,
+                DTA_VIRTUALHEIGHTF,    resolution.y,
+                DTA_KEEPRATIO, true, DTA_HUDRules);
+            }
+
+
+            }            
+        }
+    }
+}
+
+Class DLRAX_BunkerRocketHelper : Thinker
+{
+    Actor rocket;
+    bool inverse;
+
+    override void Tick()
+    {
+        if(!rocket)
+        {
+            Destroy();
+            return;
+        }
+        
+        if(!rocket.bMISSILE)
+        {
+            rocket.bNOGRAVITY = true;
+            rocket.bROLLSPRITE = false;
+            rocket.bSPRITEANGLE = false;
+            Destroy();
+            return;
+        }
+
+        rocket.spriteangle += 4;
+        if(inverse)
+        {
+            rocket.roll += 8;
+        }
+        else
+        {
+            rocket.roll -= 8;
+        }
+        Super.Tick();
+    }
+
+    void Init()
+    {
+        if(!rocket)
+        {
+            Destroy();
+            return;
+        }
+
+        inverse = random(0, 1);
+
+        rocket.A_SetSize(7, 7);
+
+        rocket.bNOGRAVITY = false;
+        rocket.A_ScaleVelocity(1.13);
+        rocket.A_ChangeVelocity(rocket.vel.x, rocket.vel.y, rocket.vel.z + 2.5, CVF_REPLACE);
+        rocket.A_SetGravity(0.4);
+        rocket.bROLLSPRITE = true;
+        rocket.roll = random(0, 360);
+        rocket.bSPRITEANGLE = true;
+        rocket.spriteangle = random(0, 360);
+        rocket.bBOUNCEONCEILINGS = true;
+        rocket.bBOUNCEONWALLS = true;
+        rocket.bBOUNCEONFLOORS = true;
+        rocket.bBOUNCEAUTOOFFFLOORONLY = true;
+        rocket.wallbouncefactor = 0.5;
+        rocket.bouncefactor = 0.6;
+        rocket.bouncecount = 4;
+        rocket.bouncesound = "weapons/grenadelauncherbounce";
+    }
+}
+/*
+class bunktest : DoomImp
+{
+    override void PostBeginPlay()
+    {
+        GiveInventory("DRLAX_BunkerShield", 1);
+        GiveInventory("DRLAX_BunkerDummyShieldActive", 1);
+    }
+}*/
+
+Class DRLAX_BunkerShield : Inventory
+{
+    DRLAX_BunkerShieldGfx shieldgfx;
+    Array<DRLAX_BunkerShieldPart> parts;
+    Array<Actor> damagers;
+    const partcount = 55;
+    int damagedue;
+    Playerinfo p;
+
+    const SHIELDMAXHP = 512;
+    const SHIELDDAMAGEFACTOR = 1.14;
+
+
+    /*static void NewTag(int playerno, string armor, string desc)
+    {
+        let a = players[playerno].mo.FindInventory(armor);
+        if(a)
+        {
+            a.SetTag(a.GetTag() .. " - \cv" .. desc);
+            String s = TexMan.GetName(a.icon);
+            s.Replace("BOX", "BCY");
+            a.icon = TexMan.CheckForTexture(s, TexMan.Type_Any, 0);
+        }
+    }*/
+
+
+    
+    override void PostBeginPlay()
+    {
+        Init();
+    }
+
+    override void Travelled()
+    {
+        Init();
+    }
+
+    void Init()
+    {
+        parts.Clear();
+
+        for(int i; i<partcount; i++)
+        {
+            DRLAX_BunkerShieldPart p = DRLAX_BunkerShieldPart(Spawn("DRLAX_BunkerShieldPart"));
+            p.owner = owner;
+            p.shield = self;
+            parts.Push(p);
+        }
+
+        shieldgfx = DRLAX_BunkerShieldGfx(Spawn("DRLAX_BunkerShieldGfx"));
+        shieldgfx.owner = owner;
+        shieldgfx.shield = self;
+
+        shieldhealth = SHIELDMAXHP;
+        shieldactive = 0;
+        poweredtics = 0;
+        activetics = 0;
+    }
+
+    int poweredtics;
+    int activetics;
+    int shieldhealth;
+    int invultics;
+    bool shieldactive;
+
+    const ONYX_SECURITY = 0;
+    const ONYX_COMBAT = 1;
+    const ONYX_COMMANDO = 2;
+    const ONYX_BALLISTIC = 3;
+    const ONYX_BULLETPROOF = 4;
+    const ONYX_CYBERWARRIOR = 5;
+    const ONYX_DUELIST = 6;
+    const ONYX_ENERGYSHIELD = 7;
+    const ONYX_GOTHIC = 8;
+    const ONYX_MEDICAL = 9;
+    const ONYX_PHASESHIFT = 10;
+    const ONYX_REPULSION = 11;
+    const ONYX_SURVIVAL = 12;
+    const ONYX_ONYX = 13;
+
+    bool onyxgot[14];
+    bool onyxnew[14];
+
+
+    static const String Armoractors[] = 
+    {
+    "RLOModGreenArmor",
+    "RLOModBlueArmor",
+    "RLOModRedArmor",
+    "RLOModBallisticVestArmor",
+    "RLOModBulletProofVestArmor",
+    "RLOModCyberwarriorArmor",
+    "RLOModDuelistArmor",
+    "RLOModEnergyShieldedVestArmor", 
+    "RLOModGothicArmor",
+    "RLOModMedicalArmor",
+    "RLOModPhaseshiftArmor",
+    "RLOModRepulsionWaveSuitArmor",
+    "RLOModSurvivalMediArmor",
+    "RLOnyxArmor"
+    };
+
+
+    static const String Armordesc[] = 
+    {
+        "YOUR SHIELD IS EXTRA RESISTANT TO BULLET ATTACKS.",
+        "YOUR SHIELD IS EXTRA RESISTANT TO PLASMA ATTACKS.",
+        "YOUR SHIELD IS EXTRA RESISTANT TO FIRE ATTACKS.",
+        "YOUR SHIELD GRANTS YOU AMMO CHAIN (LESS AMMO USED FOR RAPID-FIRE WEAPONS).",
+        "YOUR SHIELD ALSO PROTECTS YOU FROM BEHIND.",
+        "YOUR SHIELD ALSO DAMAGES MONSTERS UP CLOSE.",
+        "PISTOLS ALSO BRING UP YOUR SHIELD",
+        "YOUR SHIELD CONSUMES LESS CELLS.",
+        "YOUR SHIELD RETALIATES WITH PLASMA SPIKES WHEN HIT.",
+        "GAIN BERSERK WHEN YOUR SHIELD BREAKS.",
+        "NO SPEED PENALTY WHILE USING YOUR SHIELD.",
+        "YOUR SHIELD KNOCKS AWAY MELEE ATTACKERS.",
+        "YOUR SHIELD REGENERATES FASTER AFTER BREAKING.",
+        "YOUR SHIELD IS 15% STRONGER."
+    };
+
+    void UpdateArmorflags()
+    {
+        for(int i = 0; i<Armordesc.Size(); i++)
+        {
+            let a = owner.FindInventory(Armoractors[i] .. "Pickup");
+            let b = owner.FindInventory(Armoractors[i] .. "Token");
+            onyxgot[i] = (a || b);
+
+            if(onyxgot[i])
+            {
+                if(a && a.GetTag() == a.default.GetTag())
+                {
+                    a.SetTag(a.GetTag() .. " - \cv" .. Armordesc[i]);
+                    String s = TexMan.GetName(a.icon);
+                    s.Replace("BOX", "BCY");
+                    a.icon = TexMan.CheckForTexture(s, TexMan.Type_Any, 0);
+                }
+
+                if(b && b.GetTag() == b.default.GetTag())
+                {
+                    b.SetTag(b.GetTag() .. " - \cv" .. Armordesc[i]);
+                    String s = TexMan.GetName(b.icon);
+                    s.Replace("BOX", "BCY");
+                    b.icon = TexMan.CheckForTexture(s, TexMan.Type_Any, 0);
+                }
+            }
+        }
+        
+        for(int i = 0; i<onyxgot.Size(); i++)
+        {
+            if(onyxgot[i])
+            {
+                if(!onyxnew[i])
+                {
+                    owner.ACS_NamedExecuteAlways("DRLA_BunkerShieldGet", 0, i);
+                    owner.A_StartSound("weapons/masterassembly", CHAN_BODY, CHANF_LOCAL);
+                    onyxnew[i] = true;
+                }
+            }
+            else
+            {
+                onyxnew[i] = false;
+            }
+        }
+    }
+
+    override void Tick()
+    {
+        if(!owner)
+        {
+            Destroy();
+            return;
+        }
+
+        if(!p)
+        {
+            p = owner.player;
+            /*
+            if(!p)
+            {
+                Destroy();
+                return;
+            }*/
+        }
+
+        if(GetAge() % 5 == 0)
+        {
+            UpdateArmorflags();
+        }
+
+        if(poweredtics > 4 && owner.health > 0)
+        {
+            if(poweredtics == 5 && !shieldactive)
+            {
+                //owner.A_TakeInventory("Cell", 2);
+            }
+
+            shieldactive = true;
+            if(!onyxgot[ONYX_PHASESHIFT]){owner.GiveInventory("DRLAX_BunkerShieldSlower", 1);}
+            owner.A_ChangeVelocity(owner.vel.x, owner.vel.y, Min(owner.vel.z, 0), CVF_REPLACE);
+        }
+        else
+        {  
+            shieldactive = false;
+            owner.TakeInventory("DRLAX_BunkerShieldSlower", 1);
+        }
+
+        if(shieldactive)
+        {
+            if((activetics % (35 * 2)) == 0)
+            {
+                owner.A_TakeInventory("Cell", 3 - (onyxgot[ONYX_ENERGYSHIELD] * 2));
+            }
+            activetics++;
+
+            if(onyxgot[ONYX_CYBERWARRIOR])
+            {
+                int yoffs = random(-64, 64);
+                int zoffs = random(-64, 64);
+                owner.A_SpawnItemEx ("DRLAX_BunkerSpark",cos(owner.pitch) * 52, yoffs,(-sin(owner.pitch) * 52) + zoffs,cos(owner.pitch)*0,0,-sin(owner.pitch)*0,0,SXF_NOCHECKPOSITION);
+            }
+        }
+        else
+        {
+            activetics = 0;
+        }
+
+        if(onyxgot[ONYX_BALLISTIC] && poweredtics > 0)
+        {
+            owner.A_GiveInventory("RLAmmoChainPerk", 1);
+        }
+        else
+        {
+            owner.A_TakeInventory("RLAmmoChainPerk", 9999);
+        }
+
+        if(FiringChaingun(p) && shieldhealth > 0)
+        {
+            if(poweredtics != 0 && (CountInv(p.ReadyWeapon.AmmoType1) == 0 && p.ReadyWeapon.AmmoType1 != null))
+            {
+                //Console.Printf("No!");
+            }
+            else
+            {
+                if(owner.CountInv("Cell") >= 3)
+                {
+                    poweredtics++;
+                }
+                else
+                {
+                    if(poweredtics > 25)
+                    {
+                        poweredtics = 25;
+                    }
+
+                    poweredtics--;
+                }
+            }
+        }
+        else
+        {
+            if(poweredtics > 0)
+            {
+                if(FindChaingun(p, true))
+                {
+                    //Console.Printf("f");
+                    if(owner.CountInv("Cell") < 5)
+                    {
+                        if(poweredtics > 25)
+                        {
+                            poweredtics = 25;
+                        }
+
+                        poweredtics--;
+                    }
+                    else
+                    {
+                        if(poweredtics > 12)
+                        {
+                            poweredtics = 12;
+                        }
+
+                        if(GetAge() % 9 == 0)
+                        {
+                            poweredtics--;
+                        }
+                    }
+                }
+                else
+                {
+                    if(poweredtics > 12)
+                    {
+                        poweredtics = 12;
+                    }
+                    poweredtics--;
+                }
+            }
+        }
+
+        if(owner.CountInv("DRLAX_BunkerDummyShieldActive") > 0 && shieldhealth > 0)
+        {
+            poweredtics = 5;
+        }
+
+        poweredtics = Max(0, poweredtics);
+
+        //Console.Printf("" .. shieldhealth);
+
+        DoDamage();
+        
+        for(int i; i<parts.Size(); i++)
+        {
+            if(parts[i])
+            {
+                Actor t = parts[i].owner;
+                int dist = 48;
+                int yoffs = ((-10 * 5) + (10 * (i % 11)));
+                int zoffs = (t.height  * 0.10) + 10 * (i / 11);
+
+                parts[i].Warp(t, cos(t.pitch) * dist, yoffs, (-sin(t.pitch) * dist) + zoffs, flags:WARPF_NOCHECKPOSITION);
+                parts[i].A_Stop();
+            }
+        }
+
+        if(shieldhealth < SHIELDMAXHP && GetAge() % 35 == 0 && owner.health > 0)
+        {
+            if(shieldactive)
+            {
+                shieldhealth += 4;
+            }
+            else
+            {
+                shieldhealth += 15;
+            }
+
+            shieldhealth = Min(shieldhealth, SHIELDMAXHP);
+
+            if(shieldhealth == 0)
+            {
+                shieldhealth = 101;
+            }
+        }
+
+        if(invultics > 0)
+        {
+            invultics--;
+        }
+
+        Super.Tick();
+    }
+
+    void DoDamage()
+    {
+        if(damagedue > 0)
+        {
+            //BreakFX();
+            owner.GiveInventory("DRLAX_BunkerDamageNotification", 1);
+
+            shieldhealth -= Clamp(damagedue, 3, 80);
+            damagedue = 0; 
+
+            if(shieldhealth <= 0)
+            {
+                // Shield death
+                BreakFX();
+                owner.A_StartSound("bunker/shieldbreak", slot:CHAN_6);
+                shieldhealth = -300;
+                poweredtics = 0;
+                shieldactive = 0;
+                activetics = 0;
+
+                if(onyxgot[ONYX_SURVIVAL])
+                {
+                    shieldhealth = -120;
+                }
+
+                if(onyxgot[ONYX_MEDICAL])
+                {
+                    owner.GiveInventory("RLBerserk", 1);
+                }
+            }
+            else
+            {
+                if(shieldhealth < 193)
+                {
+                    owner.A_StartSound("bunker/shieldwarning", slot:CHAN_7, flags:CHANF_NOSTOP);
+                }
+                invultics = 4;
+            }
+        }
+
+        damagers.Clear();
+    }
+
+    static const String Chainguns[] = 
+		{
+		"RLChaingun", 
+		"RLMinigun",
+        "RLHighPowerChaingun",
+        "RLHighPowerMinigun",
+        "RLGatlingGun",
+        "RLAssaultRifleChaingun",
+        "RLAssaultRifleMinigun",
+        "RLBurstCannonChaingun",
+        "RLBurstCannonMinigun",
+        "RLBulletstormChaingun",
+        "RLLaserMinigun",
+        "RLDemolitionAmmoChaingun",
+        "RLDemolitionAmmoMinigun",
+        "RLAutocannon",
+        "RLNanoManufactureAmmoChaingun",
+        "RLNanoManufactureAmmoMinigun"
+		};
+
+    bool FiringChaingun(Playerinfo p)
+    {
+        if(!p)
+        {
+            return false;
+        }
+
+        if((p.cmd.buttons & BT_ATTACK))
+        {
+            return(FindChaingun(p, true));
+        }
+
+        return false;
+    }
+
+    bool FindChaingun(Playerinfo p, bool allowpistols)
+    {
+        if(!p)
+        {
+            return true;
+        }
+
+        if(onyxgot[ONYX_DUELIST] && allowpistols && p.readyweapon is "RLPistolWeapon")
+        {
+        //Console.Printf("f");
+            return true;
+        }
+
+        for(int i = 0; i<Chainguns.Size(); i++)
+        {
+            if(p.ReadyWeapon is (Chainguns[i]))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    override void ModifyDamage (int damage, Name damageType, out int newdamage, bool passive, Actor inflictor, Actor source, int flags)
+    {
+        if(!passive && FindChaingun(owner.player, false) && flags & DMG_PLAYERATTACK)
+        {
+            if(source)
+            {
+                DRLAX_BunkerPlasmaAddDamage p = DRLAX_BunkerPlasmaAddDamage(Spawn("DRLAX_BunkerPlasmaAddDamage", owner.pos));
+                if(p)
+                {
+                    p.target = owner;
+                    p.tracer = source;
+                    p.plsdamage = damage;
+                }
+            }
+        }
+
+        if(passive && damage > 0)
+        {
+            if(shieldactive && (flags & DMG_EXPLOSION))
+            {
+                if(AbsAngle(owner.angle, owner.AngleTo(inflictor)) <= 75)
+                {
+                    newdamage = 0;
+                }
+            }
+
+            String s = damageType;
+            s.ToLower();
+            if(onyxgot[ONYX_REPULSION] && shieldactive && owner.CountInv("DRLAX_BunkerRepulseCooldown") == 0 && s == "melee")
+            {
+                owner.GiveInventory("DRLAX_BunkerRepulseCooldown", 1);
+                owner.A_RadiusThrust(40000, 512, RTF_NOTMISSILE|RTF_NOIMPACTDAMAGE, 320);
+                owner.A_PlaySound("misc/onyxgot[ONYX_REPULSION]wave", CHAN_WEAPON);
+            }
+
+            if(onyxgot[ONYX_BULLETPROOF] && shieldactive)
+            {
+                parts[random(0, partcount-1)].DamageMobj(inflictor, source, damage, damageType, flags);
+                newdamage = 0;
+            }
+        }
+    }
+
+    void BreakFX()
+    {
+        for(int i; i<parts.Size(); i++)
+        {
+            Actor t = owner;
+            int dist = 48;
+            int yoffs = (-100 + (20 * (i % 11)));
+            int zoffs = (t.height  * 0.10) + 20 * (i / 11);
+            int spd = frandom(15, 25);
+            //parts[i].Warp(t, cos(t.pitch) * dist, yoffs, (-sin(t.pitch) * dist) + zoffs, flags:WARPF_NOCHECKPOSITION);
+            t.A_SpawnItemEx ("DRLAX_BunkerShieldBreak",cos(t.pitch) * dist, yoffs,(-sin(t.pitch) * dist) + zoffs,cos(t.pitch)*spd,0,-sin(t.pitch)*spd,0,SXF_NOCHECKPOSITION);
+        }
+
+        Actor a = Actor(Spawn("DRLAX_BunkerShieldGfxFlash", shieldgfx.pos));
+        a.pitch = shieldgfx.pitch;
+        a.angle = shieldgfx.angle;
+    }
+}
+
+class DRLAX_BunkerPlasmaAddDamage : Actor
+{
+    Default
+    {
+        +NOINTERACTION;
+        -SOLID;
+    }
+
+    int plsdamage;
+
+    states
+    {
+        Spawn:
+        TNT1 A 1;
+        TTN1 A 0
+        {
+            if(tracer && target && tracer.health>0)
+            {
+                tracer.DamageMobj(self, target, plsdamage * 0.5, "Plasma", DMG_THRUSTLESS|DMG_NO_PAIN, 0);
+            }
+        }
+        stop;
+    }
+}
+
+class DRLAX_BunkerDummyShieldActive : Inventory
+{
+
+}
+
+Class DRLAX_BunkerDamageNotification : Powerup
+{
+    Default
+    {
+        powerup.duration 12;
+    }
+}
+
+Class DRLAX_BunkerShieldGfx : Actor
+{
+    Default
+    {
+        +FLATSPRITE;
+        +NOINTERACTION;
+        -SOLID;
+        +NOGRAVITY;
+        +BRIGHT;
+        Height 1;
+        Radius 1;
+        renderstyle "Style_ADD";
+        Alpha 0.5;
+        xscale 0.4;
+        yscale 0.0;
+    }
+
+    Actor owner;
+    DRLAX_BunkerShield shield;
+
+    states
+    {
+        Spawn:
+        BUNS KJIHGFEDCB 2;
+        loop;
+    }
+
+    override void Tick()
+    {
+        if(shield)
+        {
+            if(shield.shieldhealth < 193)
+            {
+                A_SetTranslation("CMMDRLA_ShieldRed");
+            }
+            else if(shield.shieldhealth < 321)
+            {
+                A_SetTranslation("CMMDRLA_ShieldAmber");
+            }
+            else
+            {
+                A_SetTranslation("");
+            }
+
+            if(scale.y < 0)
+            {
+                scale.y = 0;
+            }
+
+            if(shield.shieldactive)
+            {
+                if(PlayerPawn(owner))
+                {
+                PlayerPawn(owner).ViewBob = 0;
+                }
+
+                if(scale.y < 0.39)
+                {
+                    scale.y += 0.05;
+                }
+
+
+                if(shield.activetics == 1)
+                {
+                    A_StopSound(CHAN_5);
+                    A_StartSound("bunker/shieldstart", CHAN_5);
+                }
+            }
+            else
+            {
+                if(PlayerPawn(owner))
+                {
+                    PlayerPawn(owner).ViewBob = PlayerPawn(owner).Default.ViewBob;
+                }
+
+                if(scale.y > 0.04)
+                {
+                    scale.y -= 0.05;
+                }
+
+                if(scale.y == 0.35 && shield.shieldhealth > 0)
+                {
+                    A_StopSound(CHAN_5);
+                    A_StartSound("bunker/shieldend", CHAN_5);
+                }
+            }
+
+            if(shield.shieldhealth <= 0)
+            {
+                scale.y = 0;
+            }
+
+            if(owner)
+            {
+                Actor t = owner;
+                int dist = 48;
+                int yoffs = 0;
+                int zoffs = owner.height * 0.8;//Round(owner.player.viewz - owner.z);
+                Warp(t, cos(t.pitch) * dist, yoffs, ((-sin(t.pitch) * dist) + zoffs), flags:WARPF_NOCHECKPOSITION|WARPF_INTERPOLATE);
+
+                float a = 1.0;
+
+                a = a - ((255 - t.cursector.LightLevel) * 0.006);
+                a = Clamp(a, 0.1, 0.5);
+
+                A_SetRenderStyle(a, STYLE_ADD);
+
+                pitch = 90 + owner.pitch;
+            }
+        }
+        Super.Tick();
+    }
+}
+
+Class DRLAX_BunkerShieldGfxFlash : DRLAX_BunkerShieldGfx
+{
+    Default
+    {
+        alpha 1.0;
+        Renderstyle "Stencil";
+        stencilcolor "White";
+        xscale 0.4;
+        yscale 0.4;
+    }
+
+    states
+    {
+        Spawn:
+        TNT1 A 0;
+        TNT1 A 0 A_Quake (6, 16, 0, 64, "");
+        BUNS K 2;
+        TNT1 A 12;
+        stop;
+    }
+
+    override void Tick()
+    {
+        Actor.Tick();
+    }
+}
+
+Class DRLAX_BunkerShieldPart : Actor
+{
+    Default
+    {
+        health 100;
+        +BUDDHA;
+        +NOGRAVITY;
+        +SHOOTABLE;
+        +NODAMAGETHRUST;
+        +DONTRIP;
+        +DONTBLAST;
+        +NOTAUTOAIMED;
+        +NOTARGET;
+        +NOBLOOD;
+        mass 99999;
+        Height 15;
+        Radius 8;
+        alpha 0.0;
+        renderstyle "Translucent";
+
+        //species "Player";
+        tag "Bunker Shield";
+    }
+
+    Actor owner;
+    DRLAX_BunkerShield shield;
+
+    states
+    {
+        Spawn:
+        TNT1 A 1;
+        loop;
+    }
+
+    bool AllyDamageSource(Actor source)
+    {
+        if(!owner.player)
+        {
+            return !(source.species == species);
+        }
+
+        return (!source.player && source.species != "Player" && !source.bFRIENDLY);
+    }
+
+    override int DamageMobj (Actor inflictor, Actor source, int damage, Name mod, int flags, double angle)
+    {
+        if(shield && shield.shieldactive && shield.invultics == 0)
+        {
+            if(!(flags & DMG_EXPLOSION))
+            {
+                Spawn("DRLAX_BunkerShieldHitFX", pos + (0,0,4));
+            }
+
+            if(source && AllyDamageSource(source))
+            {
+                if(flags & DMG_EXPLOSION)
+                {
+                    if(shield.damagers.Find(source) == shield.damagers.Size())
+                    {
+                        shield.damagers.Push(source);
+                    }
+                    else
+                    {
+                        return super.DamageMobj(inflictor, source, damage, mod, flags, angle);
+                    }
+                }
+
+                String m = mod;
+                m.ToLower();
+
+                if(shield.onyxgot[shield.ONYX_ONYX])
+                {   
+                    damage = damage * 0.85;
+                }
+
+                if(shield.onyxgot[shield.ONYX_SECURITY] && m == "bullet")
+                {
+                    damage = damage * 0.5;
+                }
+
+                if(shield.onyxgot[shield.ONYX_COMBAT] && m == "plasma")
+                {
+                    damage = damage * 0.5;
+                }
+
+                if(shield.onyxgot[shield.ONYX_COMMANDO] && m == "fire")
+                {
+                    damage = damage * 0.5;
+                }
+
+                shield.damagedue += damage * shield.SHIELDDAMAGEFACTOR;
+
+                if(shield.onyxgot[shield.ONYX_GOTHIC])
+                {
+                    //SpawnMissile(shield.shieldgfx, "DRLAX_BunkerSpike", shield.owner);
+                    let a = Spawn("DRLAX_BunkerSpike", pos);
+                    a.target = shield.owner;
+                    a.Vel3DFromAngle(50, shield.owner.angle, shield.owner.pitch);
+                    a.pitch = shield.owner.pitch;
+                    a.angle = shield.owner.angle;
+                }
+
+                return super.DamageMobj(inflictor, source, damage, mod, flags, angle);
+            }
+        }
+
+
+        return 0;
+    }
+
+    override void Tick()
+    {
+        if(owner)
+        {
+            species = owner.species;
+        }
+        if(shield && shield.shieldactive)
+        {
+            bSHOOTABLE = true;
+            bINVISIBLE = false;
+
+            if(shield.onyxgot[shield.ONYX_CYBERWARRIOR] && GetAge() % 5 == 0 && random(0, 11) == 0)
+            {
+                DRLAX_BunkerShieldAttack a = DRLAX_BunkerShieldAttack(Spawn("DRLAX_BunkerShieldAttack",pos));
+                a.target = owner;
+            }
+        }  
+        else
+        {
+            bSHOOTABLE = false;
+            bINVISIBLE = true;
+        }
+        Super.Tick();
+    }
+
+    override bool CanCollideWith(Actor other, bool passive)
+    {
+        if(passive && other && other.bMISSILE && other.target && other.target.player)
+        {
+            return false;
+        }   
+
+        return Super.CanCollideWith(other, passive);
+    }
+}
+
+Class DRLAX_BunkerRepulseCooldown : Powerup
+{
+    Default
+    {
+        powerup.duration 20;
+    }
+}
+
+class DRLAX_BunkerShieldAttack : Actor
+{
+    Default
+    {
+        height 10;
+        radius 8;
+        +MISSILE;
+        damagetype "Melee";
+        +THRUSPECIES;
+        +MTHRUSPECIES;
+        species "Player";
+        damage 1;
+    }
+
+    states
+    {
+        Spawn:
+        TNT1 A 1;
+        stop;
+    }
+}
+
+Class DRLAX_BunkerShieldSlower : PowerSpeed
+{
+    Default
+    {
+        powerup.duration 3;
+        speed 0.51;
+    }
+}
+
+Class DRLAX_BunkerShieldHitFX : Actor
+{
+    Default
+    {
+        +NOINTERACTION;
+        +NOGRAVITY;
+        height 2;
+        radius 2;
+        translation "CMMDRLA_Shield";
+        +BRIGHT;
+        Alpha 0.8;
+        renderstyle "Style_ADD";
+    }
+
+    states
+    {
+        Spawn:
+        LSOK ABCDEF 2;
+        TNT1 A 5;
+        stop;
+    }
+
+    override void PostBeginPlay()
+    {
+        A_StartSound("bunker/shieldhit");
+    }
+}
+
+class DRLAX_BunkerShieldBreak : Actor
+{
+    Default
+    {
+        +NOGRAVITY;
+        +MISSILE;
+        +BOUNCEONWALLS;
+        +BOUNCEONFLOORS;
+        +THRUACTORS;
+        +BRIGHT;
+        renderstyle "Add";
+        alpha 0.5;
+        height 2;
+        radius 2;
+        +FLATSPRITE;
+        +ROLLSPRITE;
+        scale 0.8;
+    }
+
+    uint fxtime;
+
+    states
+    {
+        Spawn:
+        TNT1 A 0;
+        TNT1 A 0
+        {
+            fxtime = random(0, 25);
+            frame = random(11, 18);
+        }
+        BUNS "#" -1;
+        stop;
+        Death:
+        TNT1 A 1;
+        stop;
+    }
+
+    override void Tick()
+    {
+        A_ScaleVelocity(0.96);
+        if(GetAge() > 35 + fxtime)
+        {
+            A_FadeOut(0.1);
+        }
+        Super.Tick();
+    }
+
+    override void PostBeginPlay()
+    {
+        roll = random(0,360);
+        angle = random(0,360);
+        pitch = random(0,360);
+    }
+}
+
+class DRLAX_BunkerSpark : Actor
+{
+    Default
+    {
+        +NOGRAVITY;
+        +NOINTERACTION;
+        +BRIGHT;
+        -SOLID;
+        height 2;
+        radius 2;
+        +FORCEXYBILLBOARD;
+        scale 0.25;
+        renderstyle "Add";
+        alpha 0.8;
+        translation "CMMDRLA_Shield";
+    }
+
+    states
+    {
+        Spawn:
+        BUNS TUVWXYZ 1;
+        stop;
+    }
+}
+
+class DRLAX_BunkerSpike : Actor
+{
+    Default
+    {
+        +MISSILE;
+        +NOGRAVITY;
+        species "Player";
+        +THRUSPECIES;
+        +MTHRUSPECIES;
+        height 8;
+        radius 8;
+        Damagetype "Piercing";
+        damage 8;
+        scale 0.5;
+        renderstyle "Add";
+        alpha 0.8;
+        translation "CMMDRLA_Shield";
+        +BRIGHT;
+        speed 20;
+    }
+
+    states
+    {
+        Spawn:
+        ZMIS A -1;
+        stop;
+    }
+}
+
+class DRLAX_BunkerRicochet : DRLAX_BaseInventory
+{
+	Default
+	{
+		Inventory.Icon "LAXITE6";
+		inventory.maxamount 1;
+		Inventory.InterhubAmount 1;
+		inventory.pickupsound "";
+		Inventory.UseSound "";
+		Inventory.PickupMessage "You picked up Bunker's ricochet rockets, you thief!";
+		//species "Player";
+		tag "Ricochet Rockets \ck(Enabled)";
+	}
+
+    bool off;
+
+	override void PressedDrop()
+	{
+
+	}
+
+	override void ConsumeItem()
+	{
+
+	}
+
+	override void DropMessage()
+	{
+		owner.A_Print("This item cannot be dropped.");
+	}
+
+	override void UseMessage()
+	{
+        if(!off)
+        {
+		    owner.A_Print("Ricochet Rockets are \ckenabled\c-. Press use again to toggle off. \c-\n\nSwitch weapons to cancel.", 8.0);
+        }
+        else
+        {
+            owner.A_Print("Ricochet Rockets are \cgdisabled\c-. Press use again to toggle on. \c-\n\nSwitch weapons to cancel.", 8.0);
+        }
+
+		owner.A_PlaySound("hud/generic");
+	}
+
+	override void UseSound()
+	{
+	}
+
+
+	override void UseFunction()
+	{
+        if(off)
+        {
+            off = false;
+		    owner.A_Print("Ricochet Rockets enabled.");
+            SetTag("Ricochet Rockets \ck(Enabled)");
+            icon = TexMan.CheckForTexture("LAXITE6", TexMan.Type_Any, 0);
+            return;
+        }
+        else
+        {
+            off = true;
+		    owner.A_Print("Ricochet Rockets disabled.");
+            SetTag("Ricochet Rockets \cg(Enabled)");
+            icon = TexMan.CheckForTexture("LAXITE7", TexMan.Type_Any, 0);
+            return;
+        }
+	}
+
+	override void PostBeginPlay()
+	{
+
+	}
+}

--- a/DoomRPG-RLArsenal-Extended/zscript/DRLAX/classes/PhaseSisters.zscript
+++ b/DoomRPG-RLArsenal-Extended/zscript/DRLAX/classes/PhaseSisters.zscript
@@ -302,7 +302,7 @@ Class RLPhaseSistersPassive : Inventory
         Class<Weapon> newwep = lastwep;
         lastwep = owner.player.ReadyWeapon.GetClass();
 
-        owner.ACS_ScriptCall("PhaseSistersShieldPartsSave");
+        owner.ACS_ScriptCall("PhaseSistersDataSave");
 
         tempitems.Copy(items);
         items.Clear();
@@ -421,7 +421,7 @@ Class RLPhaseSistersPassive : Inventory
 
         lasthealth = newhealth;
 
-        owner.ACS_ScriptCall("PhaseSistersShieldPartsLoad");
+        owner.ACS_ScriptCall("PhaseSistersDataLoad");
 
         SetLimits();
     }

--- a/DoomRPG-RLArsenal-Extended/zscript/DRLAX/classes/Trespasser.zscript
+++ b/DoomRPG-RLArsenal-Extended/zscript/DRLAX/classes/Trespasser.zscript
@@ -23,7 +23,35 @@ Class RLTrespasserEvents : EventHandler
 
         if(s)
         {
-            int aspectoffs;
+			int X = CVar.GetCVar("drpg_drla_x", players[consoleplayer]).GetInt();
+			int Y = CVar.GetCVar("drpg_drla_y", players[consoleplayer]).GetInt();   
+			int XOff = - 120, YOff = - 10;	
+
+            if(Screen.GetAspectRatio() < 1.3)
+            {
+                XOff = - 259;
+                YOff = + 5;
+            }
+            else if(Screen.GetAspectRatio() < 1.4)
+            {
+                XOff = - 228;
+                YOff = - 10;
+            }
+            else if(Screen.GetAspectRatio() < 1.7)
+            {
+                XOff = - 163;
+                YOff = - 10;
+            }
+            else if(Screen.GetAspectRatio() < 1.8)
+            {
+                XOff = - 120;
+                YOff = - 10;
+            }			
+            else if(Screen.GetAspectRatio() > 2.3)
+            {
+                XOff = + 22;
+                YOff = - 10;
+            }
 
             let window_aspect    = 1.0 * Screen.GetWidth() / Screen.GetHeight();
             let resolution        = 480 * (window_aspect, 1);
@@ -38,7 +66,7 @@ Class RLTrespasserEvents : EventHandler
 			}
 			//Console.Printf("" .. Abs(cos(s.GetAge() * 5)));
 
-            Screen.DrawTexture(TexMan.CheckForTexture("TRSMKCD", TexMan.Type_Sprite, 0), false, 692, 65,
+            Screen.DrawTexture(TexMan.CheckForTexture("TRSMKCD", TexMan.Type_Sprite, 0), false, X + XOff, Y + YOff,
 			DTA_ALPHA, alpha,
             DTA_VIRTUALWIDTHF,    resolution.x,
             DTA_VIRTUALHEIGHTF,    resolution.y,

--- a/DoomRPG/GAMEINFO.txt
+++ b/DoomRPG/GAMEINFO.txt
@@ -1,3 +1,3 @@
-startuptitle = "Doom RPG SE Rebalance (2023-09-03)"
+startuptitle = "Doom RPG SE Rebalance (2023-09-06)"
 startupcolors = "0092FF", "000000"
 startuptype = "Hexen"

--- a/DoomRPG/scripts/CharSave.c
+++ b/DoomRPG/scripts/CharSave.c
@@ -307,12 +307,53 @@ NamedScript MenuEntry void SaveCharacter()
 
     // Bulk Deposit
     DepositInventory();
-    while (Depositing)
+
+    // Compatibility Handling - DoomRL Extended
+    // Deposit Items for Phase Sisters
+    if (CompatModeEx == COMPAT_DRLAX && PlayerClass(PlayerNumber()) == 9) // Phase Sisters
     {
-        SetFont("BIGFONT");
-        HudMessage("\CkDepositing Items: \Cd%d \C-/ \Cd%d", DepositItems, DepositTotal);
-        EndHudMessage(HUDMSG_FADEOUT, DEPOSIT_ID, "White", 0.5, 0.5, 0.05, 0.5);
+        while (Depositing)
+        {
+            SetFont("BIGFONT");
+            if (CheckInventory("RLPhaseSistersSwapToken") == 1)
+                HudMessage("\CtPortia:\C- \CkDepositing Items: \Cd%d \C-/ \Cd%d", DepositItems, DepositTotal);
+            else
+                HudMessage("\CvTerri:\C- \CkDepositing Items: \Cd%d \C-/ \Cd%d", DepositItems, DepositTotal);
+            EndHudMessage(HUDMSG_FADEOUT, DEPOSIT_ID, "White", 0.5, 0.5, 0.05, 0.5);
+            Delay(1);
+        }
+
+        // Swap Sisters
+        SetInventory("RLPhaseSistersHomingTrigger", 1);
+
         Delay(1);
+
+        // Disable Shield
+        DeactivateShield();
+
+        // Bulk Deposit
+        DepositInventory();
+
+        while (Depositing)
+        {
+            SetFont("BIGFONT");
+            if (CheckInventory("RLPhaseSistersSwapToken") == 1)
+                HudMessage("\CtPortia:\C- \CkDepositing Items: \Cd%d \C-/ \Cd%d", DepositItems, DepositTotal);
+            else
+                HudMessage("\CvTerri:\C- \CkDepositing Items: \Cd%d \C-/ \Cd%d", DepositItems, DepositTotal);
+            EndHudMessage(HUDMSG_FADEOUT, DEPOSIT_ID, "White", 0.5, 0.5, 0.05, 0.5);
+            Delay(1);
+        }
+    }
+    else
+    {
+        while (Depositing)
+        {
+            SetFont("BIGFONT");
+            HudMessage("\CkDepositing Items: \Cd%d \C-/ \Cd%d", DepositItems, DepositTotal);
+            EndHudMessage(HUDMSG_FADEOUT, DEPOSIT_ID, "White", 0.5, 0.5, 0.05, 0.5);
+            Delay(1);
+        }
     }
 
     SetFont("BIGFONT");

--- a/DoomRPG/scripts/Map.c
+++ b/DoomRPG/scripts/Map.c
@@ -608,6 +608,16 @@ Start:
             HealThing(MAX_HEALTH);
             Players(i).EP = Players(i).EPMax;
 
+            // Compatibility Handling - DoomRL Extended
+            // Restore Health/EP for Phase Sisters
+            if (CompatModeEx == COMPAT_DRLAX && PlayerClass(PlayerNumber()) == 9) // Phase Sisters
+            {
+                Player.Portia.ActualHealth = Player.HealthMax;
+                Player.Portia.EP = Player.EPMax;
+                Player.Terri.ActualHealth = Player.HealthMax;
+                Player.Terri.EP = Player.EPMax;
+            }
+
             HudMessage("Items Found Bonus!\nFull HP/EP Restore");
             EndHudMessage(HUDMSG_FADEOUT, 0, "LightBlue", 1.5, 0.6, 3.0, 3.0);
         }
@@ -664,6 +674,16 @@ Start:
 
             HealThing(MAX_HEALTH);
             Players(i).EP = Players(i).EPMax;
+
+            // Compatibility Handling - DoomRL Extended
+            // Restore Health/EP for Phase Sisters
+            if (CompatModeEx == COMPAT_DRLAX && PlayerClass(PlayerNumber()) == 9) // Phase Sisters
+            {
+                Player.Portia.ActualHealth = Player.HealthMax;
+                Player.Portia.EP = Player.EPMax;
+                Player.Terri.ActualHealth = Player.HealthMax;
+                Player.Terri.EP = Player.EPMax;
+            }
 
             if (Players(i).Level < MAX_LEVEL && Players(i).RankLevel < MAX_RANK)
             {

--- a/DoomRPG/scripts/Outpost.c
+++ b/DoomRPG/scripts/Outpost.c
@@ -145,6 +145,38 @@ NamedScript MapSpecial void RegenArea(int ID)
 
             AddHealthDirect(HealthCharges, 100);
             TakeInventory("DRPGCredits", HealthCharges);
+
+            // Compatibility Handling - DoomRL Extended
+            // Restore Health for Phase Sisters
+            if (CompatModeEx == COMPAT_DRLAX && PlayerClass(PlayerNumber()) == 9) // Phase Sisters
+            {
+                // For Portia
+                if (CheckInventory("RLPhaseSistersSwapToken") == 0)
+                {
+                    if (CheckInventory("DRPGCredits") > 0 && Player.Portia.ActualHealth < Player.HealthMax)
+                    {
+                        HealthCharges = Player.HealthMax - Player.Portia.ActualHealth;
+                        if (HealthCharges > CheckInventory("DRPGCredits"))
+                            HealthCharges = CheckInventory("DRPGCredits");
+                        Player.Portia.ActualHealth = Player.HealthMax;
+                        TakeInventory("DRPGCredits", HealthCharges);
+                    }
+                }
+
+                // For Terri
+                if (CheckInventory("RLPhaseSistersSwapToken") == 1)
+                {
+                    if (CheckInventory("DRPGCredits") > 0 && Player.Terri.ActualHealth < Player.HealthMax)
+                    {
+                        HealthCharges = Player.HealthMax - Player.Terri.ActualHealth;
+                        if (HealthCharges > CheckInventory("DRPGCredits"))
+                            HealthCharges = CheckInventory("DRPGCredits");
+                        Player.Terri.ActualHealth = Player.HealthMax;
+                        TakeInventory("DRPGCredits", HealthCharges);
+                    }
+                }
+            }
+
             DoMessage = true;
         }
 
@@ -194,15 +226,28 @@ NamedScript MapSpecial void RegenArea(int ID)
         if (CheckInventory("Armor") >= GetArmorInfo(ARMORINFO_SAVEAMOUNT))
             return;
 
+        str ArmorExceptions[6] =
+        {
+            "RLFireShieldArmor",
+            "RLTowerShieldArmor",
+            "RLBallisticShieldArmor",
+            "RLEnergyShieldArmor",
+            "RLPlasmaShieldArmor",
+            "RLRechargeableEnergyShieldArmor"
+        };
+
         if (CompatMode == COMPAT_DRLA)
         {
-            if (CheckInventory("RLFireShieldArmorToken") || CheckInventory("RLTowerShieldArmorToken") || CheckInventory("RLBallisticShieldArmorToken") || CheckInventory("RLEnergyShieldArmorToken") || CheckInventory("RLPlasmaShieldArmorToken") || CheckInventory("RLRechargeableEnergyShieldArmorToken"))
+            for (int i = 0; i < 6; i++)
             {
-                SetFont("BIGFONT");
-                HudMessage("This type of armor can't be repairing");
-                EndHudMessage(HUDMSG_FADEOUT, 1, "Red", 0.5, 0.33, 2.0, 0.5);
-                ActivatorSound("menu/error", 127);
-                return;
+                if (GetArmorInfoString(ARMORINFO_CLASSNAME) == ArmorExceptions[i])
+                {
+                    SetFont("BIGFONT");
+                    HudMessage("This type of armor can't be repairing");
+                    EndHudMessage(HUDMSG_FADEOUT, 1, "Red", 0.5, 0.33, 2.0, 0.5);
+                    ActivatorSound("menu/error", 127);
+                    return;
+                }
             }
         }
 
@@ -228,6 +273,49 @@ NamedScript MapSpecial void RegenArea(int ID)
         EndHudMessage(HUDMSG_FADEOUT, 0, "Green", 0.5, 0.33, 2.0, 0.5);
         FadeRangeFlash(0, 255, 0, 0.5, 0, 255, 0, 0.0, 1.0);
         ActivatorSound("regen/armor", 127);
+
+        // Compatibility Handling - DoomRL Extended
+        // Restore Energy Shield for Phase Sisters
+        if (CompatModeEx == COMPAT_DRLAX && PlayerClass(PlayerNumber()) == 9) // Phase Sisters
+        {
+            // For Portia
+            if (CheckInventory("RLPhaseSistersSwapToken") == 0)
+            {
+                for (int i = 0; i < 6; i++)
+                    if (Player.Portia.ArmorName == ArmorExceptions[i])
+                        return;
+
+                ArmorPercent = Player.Portia.ArmorDurability * 100 / Player.Portia.ArmorDurabilityMax;
+                ArmorFee = (100 - ArmorPercent) / 5 * 5;
+                if (ArmorFee < 5)
+                    ArmorFee = 5;
+
+                if (CheckInventory("DRPGCredits") >= ArmorFee)
+                {
+                    Player.Portia.ArmorDurability = Player.Portia.ArmorDurabilityMax;
+                    TakeInventory("DRPGCredits", ArmorFee);
+                }
+            }
+
+            // For Terri
+            if (CheckInventory("RLPhaseSistersSwapToken") == 1)
+            {
+                for (int i = 0; i < 6; i++)
+                    if (Player.Terri.ArmorName == ArmorExceptions[i])
+                        return;
+
+                ArmorPercent = Player.Terri.ArmorDurability * 100 / Player.Terri.ArmorDurabilityMax;
+                ArmorFee = (100 - ArmorPercent) / 5 * 5;
+                if (ArmorFee < 5)
+                    ArmorFee = 5;
+
+                if (CheckInventory("DRPGCredits") >= ArmorFee)
+                {
+                    Player.Terri.ArmorDurability = Player.Terri.ArmorDurabilityMax;
+                    TakeInventory("DRPGCredits", ArmorFee);
+                }
+            }
+        }
     }
 
     // EP (and Shields)
@@ -252,6 +340,49 @@ NamedScript MapSpecial void RegenArea(int ID)
             Player.Shield.Charge += ShieldGive;
 
             TakeInventory("DRPGCredits", ShieldCharges);
+
+            // Compatibility Handling - DoomRL Extended
+            // Restore Energy Shield for Phase Sisters
+            if (CompatModeEx == COMPAT_DRLAX && PlayerClass(PlayerNumber()) == 9) // Phase Sisters
+            {
+                // For Portia
+                if (CheckInventory("RLPhaseSistersSwapToken") == 0)
+                {
+                    if (CheckInventory("DRPGCredits") > 0 && Player.Portia.Shield.Charge < Player.Portia.Shield.Capacity)
+                    {
+                        ShieldCharges = (Player.Portia.Shield.Capacity - Player.Portia.Shield.Charge) / 5;
+                        if (Player.Portia.Shield.Charge % 5 > 0)
+                            ShieldCharges++;
+                        if (CheckInventory("DRPGCredits") < ShieldCharges)
+                            ShieldCharges = CheckInventory("DRPGCredits");
+                        ShieldGive = ShieldCharges * 5;
+
+                        if (Player.Portia.Shield.Charge + ShieldGive > Player.Portia.Shield.Capacity)
+                            ShieldGive = Player.Portia.Shield.Capacity - Player.Portia.Shield.Charge;
+                        Player.Portia.Shield.Charge += ShieldGive;
+                        TakeInventory("DRPGCredits", ShieldCharges);
+                    }
+                }
+
+                // For Terri
+                if (CheckInventory("RLPhaseSistersSwapToken") == 1)
+                {
+                    if (CheckInventory("DRPGCredits") > 0 && Player.Terri.Shield.Charge < Player.Terri.Shield.Capacity)
+                    {
+                        ShieldCharges = (Player.Terri.Shield.Capacity - Player.Terri.Shield.Charge) / 5;
+                        if (Player.Terri.Shield.Charge % 5 > 0)
+                            ShieldCharges++;
+                        if (CheckInventory("DRPGCredits") < ShieldCharges)
+                            ShieldCharges = CheckInventory("DRPGCredits");
+                        ShieldGive = ShieldCharges * 5;
+
+                        if (Player.Terri.Shield.Charge + ShieldGive > Player.Terri.Shield.Capacity)
+                            ShieldGive = Player.Terri.Shield.Capacity - Player.Terri.Shield.Charge;
+                        Player.Terri.Shield.Charge += ShieldGive;
+                        TakeInventory("DRPGCredits", ShieldCharges);
+                    }
+                }
+            }
 
             SetFont("BIGFONT");
             HudMessage("Shield restored");
@@ -302,6 +433,47 @@ NamedScript MapSpecial void RegenArea(int ID)
             Player.EP += EPGive;
 
             TakeInventory("DRPGCredits", EPCharges);
+
+            // Compatibility Handling - DoomRL Extended
+            // Restore EP for Phase Sisters
+            if (CompatModeEx == COMPAT_DRLAX && PlayerClass(PlayerNumber()) == 9) // Phase Sisters
+            {
+                // For Portia
+                if (CheckInventory("RLPhaseSistersSwapToken") == 0)
+                {
+                    if (CheckInventory("DRPGCredits") > 0 && Player.Portia.EP < Player.EPMax)
+                    {
+                        EPCharges = (Player.EPMax - Player.Portia.EP) / 5;
+                        if (Player.Portia.EP % 5 > 0)
+                            EPCharges++;
+                        if (CheckInventory("DRPGCredits") < EPCharges)
+                            EPCharges = CheckInventory("DRPGCredits");
+                        EPGive = EPCharges * 5;
+                        if (Player.Portia.EP + EPGive > Player.EPMax)
+                            EPGive = Player.EPMax - Player.Portia.EP;
+                        Player.Portia.EP += EPGive;
+                        TakeInventory("DRPGCredits", EPCharges);
+                    }
+                }
+
+                // For Terri
+                if (CheckInventory("RLPhaseSistersSwapToken") == 1)
+                {
+                    if (CheckInventory("DRPGCredits") > 0 && Player.Portia.EP < Player.EPMax)
+                    {
+                        EPCharges = (Player.EPMax - Player.Terri.EP) / 5;
+                        if (Player.Terri.EP % 5 > 0)
+                            EPCharges++;
+                        if (CheckInventory("DRPGCredits") < EPCharges)
+                            EPCharges = CheckInventory("DRPGCredits");
+                        EPGive = EPCharges * 5;
+                        if (Player.Terri.EP + EPGive > Player.EPMax)
+                            EPGive = Player.EPMax - Player.Terri.EP;
+                        Player.Terri.EP += EPGive;
+                        TakeInventory("DRPGCredits", EPCharges);
+                    }
+                }
+            }
 
             SetFont("BIGFONT");
             HudMessage("EP restored");

--- a/DoomRPG/scripts/RPG.c
+++ b/DoomRPG/scripts/RPG.c
@@ -269,6 +269,19 @@ NamedScript Type_ENTER void Init()
             Player.WeaponLegendaryChance = 0.2;
         }
 
+        // Compatibility Handling - DoomRL Extended
+        if (CompatModeEx == COMPAT_DRLAX)
+        {
+            // Default Health/EP for Phase Sisters
+            if (PlayerClass(PlayerNumber()) == 9) // Phase Sisters
+            {
+                Player.Portia.ActualHealth = 50 + ((Player.Level + 1) / 2) * 5 + Player.VitalityTotal * 5;
+                Player.Portia.EP = 50 + ((Player.Level + 1) / 2) * 5 + Player.EnergyTotal * 5;
+                Player.Terri.ActualHealth = 50 + ((Player.Level + 1) / 2) * 5 + Player.VitalityTotal * 5;
+                Player.Terri.EP = 50 + ((Player.Level + 1) / 2) * 5 + Player.EnergyTotal * 5;
+            }
+        }
+
         // Compatibility Handling - DoomRL Monsters
         if (CompatMonMode == COMPAT_DRLA)
             if (CurrentLevel->UACBase)
@@ -475,22 +488,52 @@ NamedScript void PlayerHealth()
     int BeforeHealth;
     int AfterHealth;
 
-    while (true)
+    // Compatibility Handling - DoomRL Extended
+    // Check Health for Phase Sisters
+    if (CompatModeEx == COMPAT_DRLAX && PlayerClass(PlayerNumber()) == 9) // Phase Sisters
     {
-        BeforeHealth = GetActorProperty(0, APROP_Health);
+        bool BeforeSwap;
+        bool AfterSwap;
 
-        // If the player's dead, terminate
-        if (BeforeHealth <= 0) break;
+        while (true)
+        {
+            BeforeSwap = CheckInventory("RLPhaseSistersSwapToken");
+            BeforeHealth = GetActorProperty(0, APROP_Health);
 
-        Delay(1);
+            // If the player's dead, terminate
+            if (BeforeHealth <= 0) break;
 
-        AfterHealth = GetActorProperty(0, APROP_Health);
+            Delay(1);
 
-        if (AfterHealth > BeforeHealth)
-            Player.ActualHealth += AfterHealth - BeforeHealth;
+            AfterSwap = CheckInventory("RLPhaseSistersSwapToken");
+            AfterHealth = GetActorProperty(0, APROP_Health);
 
-        // Update health
-        SetActorProperty(0, APROP_Health, Player.ActualHealth);
+            if (AfterHealth > BeforeHealth && AfterSwap == BeforeSwap)
+                Player.ActualHealth += AfterHealth - BeforeHealth;
+
+            // Update health
+            SetActorProperty(0, APROP_Health, Player.ActualHealth);
+        }
+    }
+    else
+    {
+        while (true)
+        {
+            BeforeHealth = GetActorProperty(0, APROP_Health);
+
+            // If the player's dead, terminate
+            if (BeforeHealth <= 0) break;
+
+            Delay(1);
+
+            AfterHealth = GetActorProperty(0, APROP_Health);
+
+            if (AfterHealth > BeforeHealth)
+                Player.ActualHealth += AfterHealth - BeforeHealth;
+
+            // Update health
+            SetActorProperty(0, APROP_Health, Player.ActualHealth);
+        }
     }
 }
 
@@ -2210,6 +2253,14 @@ NamedScript void Loadout_GiveDRLAEquipment()
     int MaxWeaponCount = GetActivatorCVar("drpg_start_drla_weapon_amount");
     int ModPackCount = 0;
     int ModPackMax = GetActivatorCVar("drpg_start_drla_modpacks");
+
+    // Compatibility Handling - DoomRL Extended
+    if (CompatModeEx == COMPAT_DRLAX)
+    {
+        // Set Weapon Count for Phase Sisters
+        if (PlayerClass(PlayerNumber()) == 9) // Phase Sisters
+            if (MaxWeaponCount > 3) MaxWeaponCount = 3;
+    }
 
     // Weapons
     if (GetActivatorCVar("drpg_start_drla_weapon_type") > 0)

--- a/DoomRPG/scripts/Shop.c
+++ b/DoomRPG/scripts/Shop.c
@@ -653,23 +653,26 @@ void DepositItem(int Page, int Index, bool CharSave, bool NoSound)
                 }
 
                 // Store the weapons modpack data
-                Player.WeaponMods[Index].Total = CheckInventory(StrParam("%SModLimit", ItemPtr->Actor));
-                if (ItemPtr->CompatMods & RL_POWER_MOD)
-                    Player.WeaponMods[Index].Power = CheckInventory(StrParam("%SPowerMod", ItemPtr->Actor));
-                if (ItemPtr->CompatMods & RL_BULK_MOD)
-                    Player.WeaponMods[Index].Bulk = CheckInventory(StrParam("%SBulkMod", ItemPtr->Actor));
-                if (ItemPtr->CompatMods & RL_AGILITY_MOD)
-                    Player.WeaponMods[Index].Agility = CheckInventory(StrParam("%SAgilityMod", ItemPtr->Actor));
-                if (ItemPtr->CompatMods & RL_TECH_MOD)
-                    Player.WeaponMods[Index].Technical = CheckInventory(StrParam("%STechnicalMod", ItemPtr->Actor));
-                if (ItemPtr->CompatMods & RL_SNIPER_MOD)
-                    Player.WeaponMods[Index].Sniper = CheckInventory(StrParam("%SSniperMod", ItemPtr->Actor));
-                if (ItemPtr->CompatMods & RL_FIREST_MOD)
-                    Player.WeaponMods[Index].Firestorm = CheckInventory(StrParam("%SFirestormMod", ItemPtr->Actor));
-                if (ItemPtr->CompatMods & RL_NANO_MOD)
-                    Player.WeaponMods[Index].Nano = CheckInventory(StrParam("%SNanoMod", ItemPtr->Actor));
-                if (ItemPtr->CompatMods & RL_DEMON_MOD)
-                    Player.WeaponMods[Index].Artifacts = CheckInventory(StrParam("%SDemonArtifacts", ItemPtr->Actor));
+                if (!CharSave || (CharSave && (CheckInventory(StrParam("%SModLimit", ItemPtr->Actor)) > Player.WeaponMods[Index].Total || CheckInventory(StrParam("%SDemonArtifacts", ItemPtr->Actor)) > Player.WeaponMods[Index].Artifacts)))
+                {
+                    Player.WeaponMods[Index].Total = CheckInventory(StrParam("%SModLimit", ItemPtr->Actor));
+                    if (ItemPtr->CompatMods & RL_POWER_MOD)
+                        Player.WeaponMods[Index].Power = CheckInventory(StrParam("%SPowerMod", ItemPtr->Actor));
+                    if (ItemPtr->CompatMods & RL_BULK_MOD)
+                        Player.WeaponMods[Index].Bulk = CheckInventory(StrParam("%SBulkMod", ItemPtr->Actor));
+                    if (ItemPtr->CompatMods & RL_AGILITY_MOD)
+                        Player.WeaponMods[Index].Agility = CheckInventory(StrParam("%SAgilityMod", ItemPtr->Actor));
+                    if (ItemPtr->CompatMods & RL_TECH_MOD)
+                        Player.WeaponMods[Index].Technical = CheckInventory(StrParam("%STechnicalMod", ItemPtr->Actor));
+                    if (ItemPtr->CompatMods & RL_SNIPER_MOD)
+                        Player.WeaponMods[Index].Sniper = CheckInventory(StrParam("%SSniperMod", ItemPtr->Actor));
+                    if (ItemPtr->CompatMods & RL_FIREST_MOD)
+                        Player.WeaponMods[Index].Firestorm = CheckInventory(StrParam("%SFirestormMod", ItemPtr->Actor));
+                    if (ItemPtr->CompatMods & RL_NANO_MOD)
+                        Player.WeaponMods[Index].Nano = CheckInventory(StrParam("%SNanoMod", ItemPtr->Actor));
+                    if (ItemPtr->CompatMods & RL_DEMON_MOD)
+                        Player.WeaponMods[Index].Artifacts = CheckInventory(StrParam("%SDemonArtifacts", ItemPtr->Actor));
+                }
 
                 // Check DRLA set bonuses
                 CheckDRLASetWeapons();
@@ -723,28 +726,40 @@ int WithdrawItem(int Page, int Index)
             }
 
             int WeaponTID = UniqueTID();
-            if (Player.WeaponMods[Player.ShopIndex].Total > 0 || Player.WeaponMods[Player.ShopIndex].Artifacts > 0) // Weapon was modded
+            if (Player.WeaponMods[Index].Total > 0 || Player.WeaponMods[Index].Artifacts > 0) // Weapon was modded
             {
                 // Re-add the mods onto the weapon
                 SpawnForced(StrParam("%SPickupModded", ItemPtr->Actor), GetActorX(0), GetActorY(0), GetActorZ(0), WeaponTID, 0);
 
-                GiveActorInventory(WeaponTID, StrParam("%SModLimit", ItemPtr->Actor), Player.WeaponMods[Player.ShopIndex].Total);
+                // Give Weapon Mods tokens
+                GiveActorInventory(WeaponTID, StrParam("%SModLimit", ItemPtr->Actor), Player.WeaponMods[Index].Total);
                 if (ItemPtr->CompatMods & RL_POWER_MOD)
-                    GiveActorInventory(WeaponTID, StrParam("%SPowerMod", ItemPtr->Actor), Player.WeaponMods[Player.ShopIndex].Power);
+                    GiveActorInventory(WeaponTID, StrParam("%SPowerMod", ItemPtr->Actor), Player.WeaponMods[Index].Power);
                 if (ItemPtr->CompatMods & RL_BULK_MOD)
-                    GiveActorInventory(WeaponTID, StrParam("%SBulkMod", ItemPtr->Actor), Player.WeaponMods[Player.ShopIndex].Bulk);
+                    GiveActorInventory(WeaponTID, StrParam("%SBulkMod", ItemPtr->Actor), Player.WeaponMods[Index].Bulk);
                 if (ItemPtr->CompatMods & RL_AGILITY_MOD)
-                    GiveActorInventory(WeaponTID, StrParam("%SAgilityMod", ItemPtr->Actor), Player.WeaponMods[Player.ShopIndex].Agility);
+                    GiveActorInventory(WeaponTID, StrParam("%SAgilityMod", ItemPtr->Actor), Player.WeaponMods[Index].Agility);
                 if (ItemPtr->CompatMods & RL_TECH_MOD)
-                    GiveActorInventory(WeaponTID, StrParam("%STechnicalMod", ItemPtr->Actor), Player.WeaponMods[Player.ShopIndex].Technical);
+                    GiveActorInventory(WeaponTID, StrParam("%STechnicalMod", ItemPtr->Actor), Player.WeaponMods[Index].Technical);
                 if (ItemPtr->CompatMods & RL_SNIPER_MOD)
-                    GiveActorInventory(WeaponTID, StrParam("%SSniperMod", ItemPtr->Actor), Player.WeaponMods[Player.ShopIndex].Sniper);
+                    GiveActorInventory(WeaponTID, StrParam("%SSniperMod", ItemPtr->Actor), Player.WeaponMods[Index].Sniper);
                 if (ItemPtr->CompatMods & RL_FIREST_MOD)
-                    GiveActorInventory(WeaponTID, StrParam("%SFirestormMod", ItemPtr->Actor), Player.WeaponMods[Player.ShopIndex].Firestorm);
+                    GiveActorInventory(WeaponTID, StrParam("%SFirestormMod", ItemPtr->Actor), Player.WeaponMods[Index].Firestorm);
                 if (ItemPtr->CompatMods & RL_NANO_MOD)
-                    GiveActorInventory(WeaponTID, StrParam("%SNanoMod", ItemPtr->Actor), Player.WeaponMods[Player.ShopIndex].Nano);
+                    GiveActorInventory(WeaponTID, StrParam("%SNanoMod", ItemPtr->Actor), Player.WeaponMods[Index].Nano);
                 if (ItemPtr->CompatMods & RL_DEMON_MOD)
-                    GiveActorInventory(WeaponTID, StrParam("%SDemonArtifacts", ItemPtr->Actor), Player.WeaponMods[Player.ShopIndex].Artifacts);
+                    GiveActorInventory(WeaponTID, StrParam("%SDemonArtifacts", ItemPtr->Actor), Player.WeaponMods[Index].Artifacts);
+
+                // Wipe Weapon Mods data
+                Player.WeaponMods[Index].Total = 0;
+                Player.WeaponMods[Index].Power = 0;
+                Player.WeaponMods[Index].Bulk = 0;
+                Player.WeaponMods[Index].Agility = 0;
+                Player.WeaponMods[Index].Technical = 0;
+                Player.WeaponMods[Index].Sniper = 0;
+                Player.WeaponMods[Index].Firestorm = 0;
+                Player.WeaponMods[Index].Nano = 0;
+                Player.WeaponMods[Index].Artifacts = 0;
             }
             else
             {

--- a/DoomRPG/scripts/Stats.c
+++ b/DoomRPG/scripts/Stats.c
@@ -312,6 +312,16 @@ void CheckLevel()
             {
                 HealThing(MAX_HEALTH);
                 Player.EP = Player.EPMax;
+
+                // Compatibility Handling - DoomRL Extended
+                // Restore Health/EP for Phase Sisters
+                if (CompatModeEx == COMPAT_DRLAX && PlayerClass(PlayerNumber()) == 9) // Phase Sisters
+                {
+                    Player.Portia.ActualHealth = Player.HealthMax;
+                    Player.Portia.EP = Player.EPMax;
+                    Player.Terri.ActualHealth = Player.HealthMax;
+                    Player.Terri.EP = Player.EPMax;
+                }
             }
 
             FadeRangeFlash(255, 255, 255, 0.5, 255, 255, 255, 0, 2.0);

--- a/DoomRPG/scripts/Utils.c
+++ b/DoomRPG/scripts/Utils.c
@@ -2734,119 +2734,154 @@ void NanomaniacTransport()
     }
 }
 
-NamedScript DECORATE void PhaseSistersShieldPartsSave()
+NamedScript DECORATE void PhaseSistersDataSave()
 {
-    // Save Energy Shield for Portia
+    // Save data for Portia
     if (CheckInventory("RLPhaseSistersSwapToken") == 1)
     {
+        // Save Health/EP for Portia
+        Player.Portia.ActualHealth = Player.ActualHealth;
+        Player.Portia.EP = Player.EP;
+
+        // Save Armor for Portia
+        Player.Portia.ArmorName = GetArmorInfoString(ARMORINFO_CLASSNAME);
+        Player.Portia.ArmorDurability = CheckInventory("BasicArmor");
+        Player.Portia.ArmorDurabilityMax = GetArmorInfo(ARMORINFO_SAVEAMOUNT);
+
+        // Save Energy Shield for Portia
         // Current Parts
-        Player.PortiaShield.Body = Player.Shield.Body;
-        Player.PortiaShield.Battery = Player.Shield.Battery;
-        Player.PortiaShield.Capacitor = Player.Shield.Capacitor;
-        Player.PortiaShield.Accessory = Player.Shield.Accessory;
+        Player.Portia.Shield.Body = Player.Shield.Body;
+        Player.Portia.Shield.Battery = Player.Shield.Battery;
+        Player.Portia.Shield.Capacitor = Player.Shield.Capacitor;
+        Player.Portia.Shield.Accessory = Player.Shield.Accessory;
 
         // Flags
-        Player.PortiaShield.Active = Player.Shield.Active;
-        Player.PortiaShield.Full = Player.Shield.Full;
+        Player.Portia.Shield.Active = Player.Shield.Active;
+        Player.Portia.Shield.Full = Player.Shield.Full;
 
         // Stats
-        Player.PortiaShield.Charge = Player.Shield.Charge;
-        Player.PortiaShield.Capacity = Player.Shield.Capacity;
-        Player.PortiaShield.Interval = Player.Shield.Interval;
-        Player.PortiaShield.ChargeRate = Player.Shield.ChargeRate;
-        Player.PortiaShield.DelayRate = Player.Shield.DelayRate;
-        Player.PortiaShield.Timer = Player.Shield.Timer;
+        Player.Portia.Shield.Charge = Player.Shield.Charge;
+        Player.Portia.Shield.Capacity = Player.Shield.Capacity;
+        Player.Portia.Shield.Interval = Player.Shield.Interval;
+        Player.Portia.Shield.ChargeRate = Player.Shield.ChargeRate;
+        Player.Portia.Shield.DelayRate = Player.Shield.DelayRate;
+        Player.Portia.Shield.Timer = Player.Shield.Timer;
 
         // Accessories
-        Player.PortiaShield.AccessoryBattery = Player.Shield.AccessoryBattery;
-        Player.PortiaShield.AccessoryTimer = Player.Shield.AccessoryTimer;
+        Player.Portia.Shield.AccessoryBattery = Player.Shield.AccessoryBattery;
+        Player.Portia.Shield.AccessoryTimer = Player.Shield.AccessoryTimer;
 
         // Accessories Position
-        Player.PortiaShield.AccessoryPosition.X = Player.Shield.AccessoryPosition.X;
-        Player.PortiaShield.AccessoryPosition.Y = Player.Shield.AccessoryPosition.Y;
-        Player.PortiaShield.AccessoryPosition.Z = Player.Shield.AccessoryPosition.Z;
-        Player.PortiaShield.AccessoryPosition.Angle = Player.Shield.AccessoryPosition.Angle;
-        Player.PortiaShield.AccessoryPosition.Pitch = Player.Shield.AccessoryPosition.Pitch;
+        Player.Portia.Shield.AccessoryPosition.X = Player.Shield.AccessoryPosition.X;
+        Player.Portia.Shield.AccessoryPosition.Y = Player.Shield.AccessoryPosition.Y;
+        Player.Portia.Shield.AccessoryPosition.Z = Player.Shield.AccessoryPosition.Z;
+        Player.Portia.Shield.AccessoryPosition.Angle = Player.Shield.AccessoryPosition.Angle;
+        Player.Portia.Shield.AccessoryPosition.Pitch = Player.Shield.AccessoryPosition.Pitch;
 
         // Deactivate Shield
-        if (Player.TerriShield.Active == false)
+        if (Player.Terri.Shield.Active == false)
             DeactivateShield();
     }
 
-    // Save Energy Shield for Terri
+    // Save data for Terri
     if (CheckInventory("RLPhaseSistersSwapToken") == 0)
     {
+        // Save Health/EP for Terri
+        Player.Terri.ActualHealth = Player.ActualHealth;
+        Player.Terri.EP = Player.EP;
+
+        // Save Armor for Terri
+        Player.Terri.ArmorName = GetArmorInfoString(ARMORINFO_CLASSNAME);
+        Player.Terri.ArmorDurability = CheckInventory("BasicArmor");
+        Player.Terri.ArmorDurabilityMax = GetArmorInfo(ARMORINFO_SAVEAMOUNT);
+
+        // Save Energy Shield for Terri
         // Current Parts
-        Player.TerriShield.Body = Player.Shield.Body;
-        Player.TerriShield.Battery = Player.Shield.Battery;
-        Player.TerriShield.Capacitor = Player.Shield.Capacitor;
-        Player.TerriShield.Accessory = Player.Shield.Accessory;
+        Player.Terri.Shield.Body = Player.Shield.Body;
+        Player.Terri.Shield.Battery = Player.Shield.Battery;
+        Player.Terri.Shield.Capacitor = Player.Shield.Capacitor;
+        Player.Terri.Shield.Accessory = Player.Shield.Accessory;
 
         // Flags
-        Player.TerriShield.Active = Player.Shield.Active;
-        Player.TerriShield.Full = Player.Shield.Full;
+        Player.Terri.Shield.Active = Player.Shield.Active;
+        Player.Terri.Shield.Full = Player.Shield.Full;
 
         // Stats
-        Player.TerriShield.Charge = Player.Shield.Charge;
-        Player.TerriShield.Capacity = Player.Shield.Capacity;
-        Player.TerriShield.Interval = Player.Shield.Interval;
-        Player.TerriShield.ChargeRate = Player.Shield.ChargeRate;
-        Player.TerriShield.DelayRate = Player.Shield.DelayRate;
-        Player.TerriShield.Timer = Player.Shield.Timer;
+        Player.Terri.Shield.Charge = Player.Shield.Charge;
+        Player.Terri.Shield.Capacity = Player.Shield.Capacity;
+        Player.Terri.Shield.Interval = Player.Shield.Interval;
+        Player.Terri.Shield.ChargeRate = Player.Shield.ChargeRate;
+        Player.Terri.Shield.DelayRate = Player.Shield.DelayRate;
+        Player.Terri.Shield.Timer = Player.Shield.Timer;
 
         // Accessories
-        Player.TerriShield.AccessoryBattery = Player.Shield.AccessoryBattery;
-        Player.TerriShield.AccessoryTimer = Player.Shield.AccessoryTimer;
+        Player.Terri.Shield.AccessoryBattery = Player.Shield.AccessoryBattery;
+        Player.Terri.Shield.AccessoryTimer = Player.Shield.AccessoryTimer;
 
         // Accessories Position
-        Player.TerriShield.AccessoryPosition.X = Player.Shield.AccessoryPosition.X;
-        Player.TerriShield.AccessoryPosition.Y = Player.Shield.AccessoryPosition.Y;
-        Player.TerriShield.AccessoryPosition.Z = Player.Shield.AccessoryPosition.Z;
-        Player.TerriShield.AccessoryPosition.Angle = Player.Shield.AccessoryPosition.Angle;
-        Player.TerriShield.AccessoryPosition.Pitch = Player.Shield.AccessoryPosition.Pitch;
+        Player.Terri.Shield.AccessoryPosition.X = Player.Shield.AccessoryPosition.X;
+        Player.Terri.Shield.AccessoryPosition.Y = Player.Shield.AccessoryPosition.Y;
+        Player.Terri.Shield.AccessoryPosition.Z = Player.Shield.AccessoryPosition.Z;
+        Player.Terri.Shield.AccessoryPosition.Angle = Player.Shield.AccessoryPosition.Angle;
+        Player.Terri.Shield.AccessoryPosition.Pitch = Player.Shield.AccessoryPosition.Pitch;
 
         // Deactivate Shield
-        if (Player.PortiaShield.Active == false)
+        if (Player.Portia.Shield.Active == false)
             DeactivateShield();
     }
 }
 
-NamedScript DECORATE void PhaseSistersShieldPartsLoad()
+NamedScript DECORATE void PhaseSistersDataLoad()
 {
-    // Load Energy Shield for Portia
+    // Load data for Portia
     if (CheckInventory("RLPhaseSistersSwapToken") == 1)
     {
+        // Load Health/EP for Portia
+        Player.ActualHealth = Player.Portia.ActualHealth;
+        Player.PrevHealth = Player.Portia.ActualHealth;
+        SetActorProperty(0, APROP_Health, Player.Portia.ActualHealth);
+        Player.EP = Player.Portia.EP;
+
+        // Load Armor for Portia
+        if (Player.Portia.ArmorDurability > 0)
+        {
+            TakeInventory("BasicArmor", 99999);
+            GiveInventory(Player.Portia.ArmorName, 1);
+            SetInventory("BasicArmor", Player.Portia.ArmorDurability);
+        }
+
+        // Load Energy Shield for Portia
         // Current Parts
-        Player.Shield.Body = Player.PortiaShield.Body;
-        Player.Shield.Battery = Player.PortiaShield.Battery;
-        Player.Shield.Capacitor = Player.PortiaShield.Capacitor;
-        Player.Shield.Accessory = Player.PortiaShield.Accessory;
+        Player.Shield.Body = Player.Portia.Shield.Body;
+        Player.Shield.Battery = Player.Portia.Shield.Battery;
+        Player.Shield.Capacitor = Player.Portia.Shield.Capacitor;
+        Player.Shield.Accessory = Player.Portia.Shield.Accessory;
 
         // Flags
-        Player.Shield.Active = Player.PortiaShield.Active;
-        Player.Shield.Full = Player.PortiaShield.Full;
+        Player.Shield.Active = Player.Portia.Shield.Active;
+        Player.Shield.Full = Player.Portia.Shield.Full;
 
         // Stats
-        Player.Shield.Charge = Player.PortiaShield.Charge;
-        Player.Shield.Capacity = Player.PortiaShield.Capacity;
-        Player.Shield.Interval = Player.PortiaShield.Interval;
-        Player.Shield.ChargeRate = Player.PortiaShield.ChargeRate;
-        Player.Shield.DelayRate = Player.PortiaShield.DelayRate;
-        Player.Shield.Timer = Player.PortiaShield.Timer;
+        Player.Shield.Charge = Player.Portia.Shield.Charge;
+        Player.Shield.Capacity = Player.Portia.Shield.Capacity;
+        Player.Shield.Interval = Player.Portia.Shield.Interval;
+        Player.Shield.ChargeRate = Player.Portia.Shield.ChargeRate;
+        Player.Shield.DelayRate = Player.Portia.Shield.DelayRate;
+        Player.Shield.Timer = Player.Portia.Shield.Timer;
 
         // Accessories
-        Player.Shield.AccessoryBattery = Player.PortiaShield.AccessoryBattery;
-        Player.Shield.AccessoryTimer = Player.PortiaShield.AccessoryTimer;
+        Player.Shield.AccessoryBattery = Player.Portia.Shield.AccessoryBattery;
+        Player.Shield.AccessoryTimer = Player.Portia.Shield.AccessoryTimer;
 
         // Accessories Position
-        Player.Shield.AccessoryPosition.X = Player.PortiaShield.AccessoryPosition.X;
-        Player.Shield.AccessoryPosition.Y = Player.PortiaShield.AccessoryPosition.Y;
-        Player.Shield.AccessoryPosition.Z = Player.PortiaShield.AccessoryPosition.Z;
-        Player.Shield.AccessoryPosition.Angle = Player.PortiaShield.AccessoryPosition.Angle;
-        Player.Shield.AccessoryPosition.Pitch = Player.PortiaShield.AccessoryPosition.Pitch;
+        Player.Shield.AccessoryPosition.X = Player.Portia.Shield.AccessoryPosition.X;
+        Player.Shield.AccessoryPosition.Y = Player.Portia.Shield.AccessoryPosition.Y;
+        Player.Shield.AccessoryPosition.Z = Player.Portia.Shield.AccessoryPosition.Z;
+        Player.Shield.AccessoryPosition.Angle = Player.Portia.Shield.AccessoryPosition.Angle;
+        Player.Shield.AccessoryPosition.Pitch = Player.Portia.Shield.AccessoryPosition.Pitch;
 
         // Activate Shield
-        if (Player.PortiaShield.Active)
+        if (Player.Portia.Shield.Active)
         {
             ActivateShield();
 
@@ -2859,40 +2894,55 @@ NamedScript DECORATE void PhaseSistersShieldPartsLoad()
         }
     }
 
-    // Load Energy Shield for Terri
+    // Load data for Terri
     if (CheckInventory("RLPhaseSistersSwapToken") == 0)
     {
+        // Load Health/EP for Terri
+        Player.ActualHealth = Player.Terri.ActualHealth;
+        Player.PrevHealth = Player.Terri.ActualHealth;
+        SetActorProperty(0, APROP_Health, Player.Terri.ActualHealth);
+        Player.EP = Player.Terri.EP;
+
+        // Load Armor for Terri
+        if (Player.Terri.ArmorDurability > 0)
+        {
+            TakeInventory("BasicArmor", 99999);
+            GiveInventory(Player.Terri.ArmorName, 1);
+            SetInventory("BasicArmor", Player.Terri.ArmorDurability);
+        }
+
+        // Load Energy Shield for Terri
         // Current Parts
-        Player.Shield.Body = Player.TerriShield.Body;
-        Player.Shield.Battery = Player.TerriShield.Battery;
-        Player.Shield.Capacitor = Player.TerriShield.Capacitor;
-        Player.Shield.Accessory = Player.TerriShield.Accessory;
+        Player.Shield.Body = Player.Terri.Shield.Body;
+        Player.Shield.Battery = Player.Terri.Shield.Battery;
+        Player.Shield.Capacitor = Player.Terri.Shield.Capacitor;
+        Player.Shield.Accessory = Player.Terri.Shield.Accessory;
 
         // Flags
-        Player.Shield.Active = Player.TerriShield.Active;
-        Player.Shield.Full = Player.TerriShield.Full;
+        Player.Shield.Active = Player.Terri.Shield.Active;
+        Player.Shield.Full = Player.Terri.Shield.Full;
 
         // Stats
-        Player.Shield.Charge = Player.TerriShield.Charge;
-        Player.Shield.Capacity = Player.TerriShield.Capacity;
-        Player.Shield.Interval = Player.TerriShield.Interval;
-        Player.Shield.ChargeRate = Player.TerriShield.ChargeRate;
-        Player.Shield.DelayRate = Player.TerriShield.DelayRate;
-        Player.Shield.Timer = Player.TerriShield.Timer;
+        Player.Shield.Charge = Player.Terri.Shield.Charge;
+        Player.Shield.Capacity = Player.Terri.Shield.Capacity;
+        Player.Shield.Interval = Player.Terri.Shield.Interval;
+        Player.Shield.ChargeRate = Player.Terri.Shield.ChargeRate;
+        Player.Shield.DelayRate = Player.Terri.Shield.DelayRate;
+        Player.Shield.Timer = Player.Terri.Shield.Timer;
 
         // Accessories
-        Player.Shield.AccessoryBattery = Player.TerriShield.AccessoryBattery;
-        Player.Shield.AccessoryTimer = Player.TerriShield.AccessoryTimer;
+        Player.Shield.AccessoryBattery = Player.Terri.Shield.AccessoryBattery;
+        Player.Shield.AccessoryTimer = Player.Terri.Shield.AccessoryTimer;
 
         // Accessories Position
-        Player.Shield.AccessoryPosition.X = Player.TerriShield.AccessoryPosition.X;
-        Player.Shield.AccessoryPosition.Y = Player.TerriShield.AccessoryPosition.Y;
-        Player.Shield.AccessoryPosition.Z = Player.TerriShield.AccessoryPosition.Z;
-        Player.Shield.AccessoryPosition.Angle = Player.TerriShield.AccessoryPosition.Angle;
-        Player.Shield.AccessoryPosition.Pitch = Player.TerriShield.AccessoryPosition.Pitch;
+        Player.Shield.AccessoryPosition.X = Player.Terri.Shield.AccessoryPosition.X;
+        Player.Shield.AccessoryPosition.Y = Player.Terri.Shield.AccessoryPosition.Y;
+        Player.Shield.AccessoryPosition.Z = Player.Terri.Shield.AccessoryPosition.Z;
+        Player.Shield.AccessoryPosition.Angle = Player.Terri.Shield.AccessoryPosition.Angle;
+        Player.Shield.AccessoryPosition.Pitch = Player.Terri.Shield.AccessoryPosition.Pitch;
 
         // Activate Shield
-        if (Player.TerriShield.Active)
+        if (Player.Terri.Shield.Active)
         {
             ActivateShield();
 
@@ -2906,9 +2956,11 @@ NamedScript DECORATE void PhaseSistersShieldPartsLoad()
     }
 }
 
-NamedScript DECORATE void DRLAX_DRPG_CursedDagger_Effect()
+NamedScript DECORATE void SetPlayerActualHealth(int ActualHealth)
 {
-    Player.ActualHealth = 10;
+    Player.ActualHealth = ActualHealth;
+    Player.PrevHealth = Player.ActualHealth;
+    SetActorProperty(0, APROP_Health, Player.ActualHealth);
 }
 
 // --------------------------------------------------

--- a/DoomRPG/scripts/inc/Structs.h
+++ b/DoomRPG/scripts/inc/Structs.h
@@ -853,56 +853,82 @@ struct PlayerData_S
     // Portia
     struct
     {
-        // Current Parts
-        struct ShieldPart_S const *Body;
-        struct ShieldPart_S const *Battery;
-        struct ShieldPart_S const *Capacitor;
-        struct ShieldAccessory_S const *Accessory;
+        // Portia's Health/EP
+        int ActualHealth;
+        int EP;
 
-        // Flags
-        bool Active;
-        bool Full;
+        // Portia's Armor
+        str ArmorName;
+        int ArmorDurability;
+        int ArmorDurabilityMax;
 
-        // Stats
-        int Charge;
-        int Capacity;
-        int Interval;
-        int ChargeRate;
-        fixed DelayRate;
-        int Timer;
+        // Portia's Energy Shield
+        struct
+        {
+            // Current Parts
+            struct ShieldPart_S const *Body;
+            struct ShieldPart_S const *Battery;
+            struct ShieldPart_S const *Capacitor;
+            struct ShieldAccessory_S const *Accessory;
 
-        // Accessories
-        int AccessoryBattery;
-        int AccessoryTimer;
-        struct Position_S AccessoryPosition;
-    } PortiaShield;
+            // Flags
+            bool Active;
+            bool Full;
+
+            // Stats
+            int Charge;
+            int Capacity;
+            int Interval;
+            int ChargeRate;
+            fixed DelayRate;
+            int Timer;
+
+            // Accessories
+            int AccessoryBattery;
+            int AccessoryTimer;
+            struct Position_S AccessoryPosition;
+        } Shield;
+    } Portia;
 
     // Terri
     struct
     {
-        // Current Parts
-        struct ShieldPart_S const *Body;
-        struct ShieldPart_S const *Battery;
-        struct ShieldPart_S const *Capacitor;
-        struct ShieldAccessory_S const *Accessory;
+        // Terri's Health/EP
+        int ActualHealth;
+        int EP;
 
-        // Flags
-        bool Active;
-        bool Full;
+        // Terri's Armor
+        str ArmorName;
+        int ArmorDurability;
+        int ArmorDurabilityMax;
 
-        // Stats
-        int Charge;
-        int Capacity;
-        int Interval;
-        int ChargeRate;
-        fixed DelayRate;
-        int Timer;
+        // Terri's Energy Shield
+        struct
+        {
+            // Current Parts
+            struct ShieldPart_S const *Body;
+            struct ShieldPart_S const *Battery;
+            struct ShieldPart_S const *Capacitor;
+            struct ShieldAccessory_S const *Accessory;
 
-        // Accessories
-        int AccessoryBattery;
-        int AccessoryTimer;
-        struct Position_S AccessoryPosition;
-    } TerriShield;
+            // Flags
+            bool Active;
+            bool Full;
+
+            // Stats
+            int Charge;
+            int Capacity;
+            int Interval;
+            int ChargeRate;
+            fixed DelayRate;
+            int Timer;
+
+            // Accessories
+            int AccessoryBattery;
+            int AccessoryTimer;
+            struct Position_S AccessoryPosition;
+        } Shield;
+    } Terri;
 
     // Associated Drops
     struct DynamicArray_S DropTID;

--- a/DoomRPG/scripts/inc/Utils.h
+++ b/DoomRPG/scripts/inc/Utils.h
@@ -152,8 +152,8 @@ void CheckDRLASetWeapons();
 void NomadModPacksSave();
 void NomadModPacksLoad();
 void NanomaniacTransport();
-NamedScript DECORATE void PhaseSistersShieldPartsSave();
-NamedScript DECORATE void PhaseSistersShieldPartsLoad();
+NamedScript DECORATE void PhaseSistersDataSave();
+NamedScript DECORATE void PhaseSistersDataLoad();
 
 // Math
 int CalcPercent(int, int);


### PR DESCRIPTION
DoomRLA Extended compatibility:
- fixed a bug when weapon modifications were lost after using the "Save Character" function;
- the new HUD elements are now tied to the DRPG-DRLA HUD (for Bunker and Tresspasser).

Phase SIsters:
- fixed bug when sister's HP was not counted correctly after swap;
- now the sisters have split EP values;
- sisters now restore HP/Health together when they level up or interact with restoring elements in Outpost;
- now saves both sisters' inventory when using the "character save" function;
- fixed a bug where it was impossible to restore armor in Outpost.